### PR TITLE
Alfrodull integration, some general improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,35 @@ endif()
 message(STATUS "HDF5 C++libraries " ${HDF5_LIBRARIES})
 include_directories("src/headers")
 
+######################################################################
+# get git version information
+# from https://stackoverflow.com/questions/1435953/how-can-i-pass-git-sha1-to-compiler-as-definition-using-cmake/4318642#4318642
+
+# The 'real' git information file
+SET(GITREV_BARE_FILE git-rev.h)
+# The temporary git information file
+SET(GITREV_BARE_TMP git-rev-tmp.h)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/ )
+SET(GITREV_FILE ${CMAKE_CURRENT_BINARY_DIR}/include/${GITREV_BARE_FILE})
+SET(GITREV_TMP ${CMAKE_CURRENT_BINARY_DIR}/include/${GITREV_BARE_TMP})
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/include/)
+
+set(GIT_BRANCH_COMMAND "git rev-parse --abbrev-ref HEAD | sed \'s/\(.*\)/\"\\1\"/g\'" )
+
+
+ADD_CUSTOM_COMMAND(
+  OUTPUT ${GITREV_TMP}
+  COMMAND echo -n \\\#define GIT_BRANCH_RAW\  > ${GITREV_TMP}
+  COMMAND echo \\\"\$\$\(git rev-parse --abbrev-ref HEAD\)\\\" >> ${GITREV_TMP} 
+  COMMAND echo -n \\\#define GIT_HASH_RAW\  >> ${GITREV_TMP}
+  COMMAND echo \\\"\$\$\(git describe --always --dirty --abbrev=40 --match=\"NoTagWithThisName\"\)\\\" >> ${GITREV_TMP} 
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different ${GITREV_TMP} ${GITREV_FILE}
+#  COMMAND ${CMAKE_COMMAND} -E remove ${GITREV_TMP}
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+#  VERBATIM
+)
+# Finally, the temporary file should be added as a dependency to the target
 
 
 ######################################################################
@@ -217,7 +246,7 @@ set(PHYSICS_LIBRARY_PATH "${MODULES_SRC}/libphy_modules.a")
 
 ######################################################################
 # build application
-add_executable(esp ${SRC})
+add_executable(esp ${SRC} ${GITREV_TMP})
 target_compile_options(esp  PUBLIC -DBUILD_LEVEL="release" -DDEVICE_SM=${SM})
 # options for debugging
 #target_compile_options(esp PUBLIC -DBENCHMARKING -DBENCH_NAN_CHECK)

--- a/Makefile
+++ b/Makefile
@@ -82,11 +82,11 @@ ifeq ($(COMP), nvcc)
 	dependencies_flags = --generate-dependencies
 
 	# define common flags
-	cpp_flags := $(ccbin)  --compiler-options  -Wall -std=c++11 -DDEVICE_SM=$(SM)
-	cuda_flags := $(ccbin) --compiler-options  -Wall -std=c++11 -DDEVICE_SM=$(SM)
+	cpp_flags := $(ccbin)  --compiler-options  -Wall -std=c++14 -DDEVICE_SM=$(SM)
+	cuda_flags := $(ccbin) --compiler-options  -Wall -std=c++14 -DDEVICE_SM=$(SM)
 
-	cpp_dep_flags := $(ccbin) -std=c++11
-	cuda_dep_flags := $(ccbin) -std=c++11
+	cpp_dep_flags := $(ccbin) -std=c++14
+	cuda_dep_flags := $(ccbin) -std=c++14
 	link_flags = $(ccbin)
 else
 	# need to compile with clang for compilation database
@@ -97,11 +97,11 @@ else
 	dependencies_flags := -MM
 
 	# define common flags
-	cpp_flags := -Wall -std=c++11 -DDEVICE_SM=$(SM)
-	cuda_flags := -Wall -std=c++11 -DDEVICE_SM=$(SM) --cuda-path=$(CUDA_PATH)
+	cpp_flags := -Wall -std=c++14 -DDEVICE_SM=$(SM)
+	cuda_flags := -Wall -std=c++14 -DDEVICE_SM=$(SM) --cuda-path=$(CUDA_PATH)
 
-	cpp_dep_flags := -std=c++11
-	cuda_dep_flags := -std=c++11 --cuda-path=$(CUDA_PATH)
+	cpp_dep_flags := -std=c++14
+	cuda_dep_flags := -std=c++14 --cuda-path=$(CUDA_PATH)
 	link_flags = --cuda-path=$(CUDA_PATH) -L$(CUDA_LIBS) -lcudart_static -ldl -lrt -pthread
 endif
 
@@ -250,7 +250,7 @@ $(BINDIR)/${TESTDIR}: $(BINDIR)
 
 # for CUDA files
 $(OBJDIR)/${OUTPUTDIR}/%.d: %.cu | $(OBJDIR)/$(OUTPUTDIR) $(OBJDIR)
-	@echo $(BLUE)computing dependencies $@ $(END)
+	@echo -e $(BLUE)computing dependencies $@ $(END)
 	set -e; rm -f $@; \
 	$(CC) $(dependencies_flags) $(arch) $(cuda_dep_flags) $(h5include) -I$(includedir)  $< > $@.$$$$; \
 	sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' < $@.$$$$ > $@; \
@@ -259,7 +259,7 @@ $(OBJDIR)/${OUTPUTDIR}/%.d: %.cu | $(OBJDIR)/$(OUTPUTDIR) $(OBJDIR)
 
 # for C++ files
 $(OBJDIR)/${OUTPUTDIR}/%.d: %.cpp | $(OBJDIR)/$(OUTPUTDIR) $(OBJDIR)
-	@echo $(BLUE)computing dependencies $@ $(END)
+	@echo -e $(BLUE)computing dependencies $@ $(END)
 	set -e; rm -f $@; \
 	$(CC) $(dependencies_flags) $(arch) $(cpp_dep_flags) $(h5include) -I$(includedir) $< > $@.$$$$; \
 	sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' < $@.$$$$ > $@; \
@@ -269,7 +269,7 @@ $(OBJDIR)/${OUTPUTDIR}/%.d: %.cpp | $(OBJDIR)/$(OUTPUTDIR) $(OBJDIR)
 # build objects
 # CUDA files
 $(OBJDIR)/${OUTPUTDIR}/%.o: %.cu $(OBJDIR)/$(OUTPUTDIR)/%.d| $(OBJDIR)/$(OUTPUTDIR) $(OBJDIR)
-	@echo $(YELLOW)creating $@ $(END)
+	@echo -e $(YELLOW)creating $@ $(END)
 	if test $$CDB = "-MJ" ; then \
 		$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) -I$(includedir) $(CDB) $@.json -o $@ $<; \
 	else \
@@ -278,7 +278,7 @@ $(OBJDIR)/${OUTPUTDIR}/%.o: %.cu $(OBJDIR)/$(OUTPUTDIR)/%.d| $(OBJDIR)/$(OUTPUTD
 
 # C++ files
 $(OBJDIR)/${OUTPUTDIR}/%.o: %.cpp $(OBJDIR)/$(OUTPUTDIR)/%.d| $(OBJDIR)/$(OUTPUTDIR) $(OBJDIR)
-	@echo $(YELLOW)creating $@ $(END)
+	@echo -e $(YELLOW)creating $@ $(END)
 	if test $$CDB = "-MJ" ; then \
 		$(CC) $(CC_comp_flag) $(arch) $(cpp_flags) $(h5include) -I$(includedir) $(CDB) $@.json -o $@ $<; \
 	else \
@@ -287,8 +287,9 @@ $(OBJDIR)/${OUTPUTDIR}/%.o: %.cpp $(OBJDIR)/$(OUTPUTDIR)/%.d| $(OBJDIR)/$(OUTPUT
 
 
 # link *.o objects
+.PHONY: 
 $(BINDIR)/${OUTPUTDIR}/esp: $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj)) $(MODULES_SRC)/libphy_modules.a | $(BINDIR) $(RESDIR) $(BINDIR)/$(OUTPUTDIR)  $(OBJDIR)
-	@echo $(YELLOW)creating $@ $(END)
+	@echo -e $(YELLOW)creating $@ $(END)
 	$(CC) -o $(BINDIR)/$(OUTPUTDIR)/esp $(arch) $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj)) -L$(MODULES_SRC) -lphy_modules $(h5libdir) $(h5libs) $(link_flags)
 	if test $$CDB = "-MJ" ; then \
 	rm -f compile_commands.json; \
@@ -300,7 +301,7 @@ $(BINDIR)/${OUTPUTDIR}/esp: $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj)) $(MODULE
 # phony so that it will always be run
 .PHONY: symlink
 symlink: $(BINDIR)/$(OUTPUTDIR)/esp
-	@echo $(BLUE)make link from $(BINDIR)/$(OUTPUTDIR)/esp to $(BINDIR)/esp  $(END)
+	@echo -e $(BLUE)make link from $(BINDIR)/$(OUTPUTDIR)/esp to $(BINDIR)/esp  $(END)
 	rm -f $(BINDIR)/esp
 	ln -s $(BINDIR)/$(OUTPUTDIR)/esp -r -t bin
 
@@ -311,7 +312,7 @@ export
 # always call submakefile for modules
 .PHONY: $(MODULES_SRC)/libphy_modules.a
 $(MODULES_SRC)/libphy_modules.a:
-	@echo $(MAGENTA)Creating physics module from subdir $(MODULES_SRC)$(END)
+	@echo -e $(MAGENTA)Creating physics module from subdir $(MODULES_SRC)$(END)
 	$(MAKE) -f Makefile -C $(MODULES_SRC)
 
 #######################################################################
@@ -324,53 +325,53 @@ $(MODULES_SRC)/libphy_modules.a:
 tests: ${BINDIR}/${TESTDIR}/cmdargs_test ${BINDIR}/${TESTDIR}/config_test ${BINDIR}/${TESTDIR}/storage_test ${BINDIR}/${TESTDIR}/directories_test ${BINDIR}/${TESTDIR}/gen_init  ${BINDIR}/${TESTDIR}/reduction_add_test
 
 $(BINDIR)/$(TESTDIR)/cmdargs_test:  $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj_tests_cmdargs)) | $(BINDIR)/${OUTPUTDIR} $(BINDIR)/$(TESTDIR) $(BINDIR) $(RESDIR)
-	@echo $(YELLOW)creating $@ $(END)
+	@echo -e $(YELLOW)creating $@ $(END)
 	$(CC) $(arch) $(link_flags) -o $(BINDIR)/$(TESTDIR)/cmdargs_test $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj_tests_cmdargs))
 
 $(BINDIR)/$(TESTDIR)/config_test:  $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj_tests_config)) | $(BINDIR)/${OUTPUTDIR} $(BINDIR)/$(TESTDIR) $(BINDIR) $(RESDIR)
-	@echo $(YELLOW)creating $@ $(END)
+	@echo -e $(YELLOW)creating $@ $(END)
 	$(CC)  $(arch) $(link_flags) -o $(BINDIR)/$(TESTDIR)/config_test $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj_tests_config))
 
 $(BINDIR)/$(TESTDIR)/directories_test:  $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj_tests_directories)) | $(BINDIR)/${OUTPUTDIR} $(BINDIR)/$(TESTDIR) $(BINDIR) $(RESDIR)
-	@echo $(YELLOW)creating $@ $(END)
+	@echo -e $(YELLOW)creating $@ $(END)
 	$(CC) $(arch) $(link_flags) -o $(BINDIR)/$(TESTDIR)/directories_test $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj_tests_directories))
 
 $(BINDIR)/$(TESTDIR)/storage_test:  $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj_tests_storage)) | $(BINDIR)/${OUTPUTDIR} $(BINDIR)/$(TESTDIR) $(BINDIR) $(RESDIR)
-	@echo $(YELLOW)creating $@ $(END)
+	@echo -e $(YELLOW)creating $@ $(END)
 	$(CC) $(arch) $(link_flags) -o $(BINDIR)/$(TESTDIR)/storage_test $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj_tests_storage))  $(h5libdir) $(h5libs)
 
 $(BINDIR)/$(TESTDIR)/gen_init:  $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj_tests_gen_init)) | $(BINDIR)/${OUTPUTDIR} $(BINDIR)/$(TESTDIR) $(BINDIR) $(RESDIR)
-	@echo $(YELLOW)creating $@ $(END)
+	@echo -e $(YELLOW)creating $@ $(END)
 	$(CC) $(arch) $(link_flags) -o $(BINDIR)/$(TESTDIR)/gen_init $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj_tests_gen_init))  $(h5libdir) $(h5libs)
 
 $(BINDIR)/$(TESTDIR)/reduction_add_test:  $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj_tests_reduction_add)) | $(BINDIR)/${OUTPUTDIR} $(BINDIR)/$(TESTDIR) $(BINDIR) $(RESDIR)
-	@echo $(YELLOW)creating $@ $(END)
+	@echo -e $(YELLOW)creating $@ $(END)
 	$(CC) $(arch) $(link_flags) -o $(BINDIR)/$(TESTDIR)/reduction_add_test $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj_tests_reduction_add))  $(h5libdir) $(h5libs)
 
 #######################################################################
 # Cleanup
 .phony: clean,ar
 clean:
-	@echo $(CYAN)clean up binaries $(END)
+	@echo -e $(CYAN)clean up binaries $(END)
 	-$(RM) $(BINDIR)/debug/esp
 	-$(RM) $(BINDIR)/release/esp
 	-$(RM) $(BINDIR)/prof/esp
-	@echo $(CYAN)clean up objects files and dependencies $(END)
+	@echo -e $(CYAN)clean up objects files and dependencies $(END)
 	-$(RM) $(OBJDIR)/debug/*.o $(OBJDIR)/debug/*.d $(OBJDIR)/debug/*.d.* $(OBJDIR)/debug/*.o.json
 	-$(RM) $(OBJDIR)/release/*.o $(OBJDIR)/release/*.d $(OBJDIR)/release/*.d.* $(OBJDIR)/release/*.o.json
 	-$(RM) $(OBJDIR)/prof/*.o $(OBJDIR)/prof/*.d $(OBJDIR)/prof/*.d.* $(OBJDIR)/prof/*.o.json
-	@echo $(CYAN)clean up tests binaries $(END)
+	@echo -e $(CYAN)clean up tests binaries $(END)
 	-$(RM) $(BINDIR)/tests/cmdargs_test
 	-$(RM) $(BINDIR)/tests/storage_test
 	-$(RM) $(BINDIR)/tests/config_test
 	-$(RM) $(BINDIR)/tests/directories_test
 	-$(RM) $(BINDIR)/tests/gen_init
 	-$(RM) $(BINDIR)/tests/test_reduction_add
-	@echo $(CYAN)clean up symlink $(END)
+	@echo -e $(CYAN)clean up symlink $(END)
 	-$(RM) $(BINDIR)/esp
-	@echo $(CYAN)clean up modules directory $(END)
+	@echo -e $(CYAN)clean up modules directory $(END)
 	$(MAKE) -C $(MODULES_SRC) clean
-	@echo $(CYAN)clean up directories $(END)
+	@echo -e $(CYAN)clean up directories $(END)
 	-$(RM) -d $(BINDIR)/debug $(BINDIR)/release $(BINDIR)/prof
 	-$(RM) -d $(BINDIR)/tests
 	-$(RM) -d $(OBJDIR)/debug

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,13 @@
 # SM number can also be set in Makefile.conf
 
 # shell colors
-RED := "\033[1;31m"
-YELLOW := "\033[1;33m"
-GREEN := "\033[1;32m"
-BLUE := "\033[1;34m"
-MAGENTA := "\033[1;35m"
-CYAN := "\033[1;36m"
-END := "\033[0m"
+RED := \033[1;31m
+YELLOW := \033[1;33m
+GREEN := \033[1;32m
+BLUE := \033[1;34m
+MAGENTA := \033[1;35m
+CYAN := \033[1;36m
+END := \033[0m
 
 
 
@@ -250,7 +250,7 @@ $(BINDIR)/${TESTDIR}: $(BINDIR)
 
 # for CUDA files
 $(OBJDIR)/${OUTPUTDIR}/%.d: %.cu | $(OBJDIR)/$(OUTPUTDIR) $(OBJDIR)
-	@echo -e $(BLUE)computing dependencies $@ $(END)
+	@echo -e '$(BLUE)computing dependencies $@ $(END)'
 	set -e; rm -f $@; \
 	$(CC) $(dependencies_flags) $(arch) $(cuda_dep_flags) $(h5include) -I$(includedir)  $< > $@.$$$$; \
 	sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' < $@.$$$$ > $@; \
@@ -259,7 +259,7 @@ $(OBJDIR)/${OUTPUTDIR}/%.d: %.cu | $(OBJDIR)/$(OUTPUTDIR) $(OBJDIR)
 
 # for C++ files
 $(OBJDIR)/${OUTPUTDIR}/%.d: %.cpp | $(OBJDIR)/$(OUTPUTDIR) $(OBJDIR)
-	@echo -e $(BLUE)computing dependencies $@ $(END)
+	@echo -e '$(BLUE)computing dependencies $@ $(END)'
 	set -e; rm -f $@; \
 	$(CC) $(dependencies_flags) $(arch) $(cpp_dep_flags) $(h5include) -I$(includedir) $< > $@.$$$$; \
 	sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' < $@.$$$$ > $@; \
@@ -269,7 +269,7 @@ $(OBJDIR)/${OUTPUTDIR}/%.d: %.cpp | $(OBJDIR)/$(OUTPUTDIR) $(OBJDIR)
 # build objects
 # CUDA files
 $(OBJDIR)/${OUTPUTDIR}/%.o: %.cu $(OBJDIR)/$(OUTPUTDIR)/%.d| $(OBJDIR)/$(OUTPUTDIR) $(OBJDIR)
-	@echo -e $(YELLOW)creating $@ $(END)
+	@echo -e '$(YELLOW)creating $@ $(END)'
 	if test $$CDB = "-MJ" ; then \
 		$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) -I$(includedir) $(CDB) $@.json -o $@ $<; \
 	else \
@@ -278,7 +278,7 @@ $(OBJDIR)/${OUTPUTDIR}/%.o: %.cu $(OBJDIR)/$(OUTPUTDIR)/%.d| $(OBJDIR)/$(OUTPUTD
 
 # C++ files
 $(OBJDIR)/${OUTPUTDIR}/%.o: %.cpp $(OBJDIR)/$(OUTPUTDIR)/%.d| $(OBJDIR)/$(OUTPUTDIR) $(OBJDIR)
-	@echo -e $(YELLOW)creating $@ $(END)
+	@echo -e '$(YELLOW)creating $@ $(END)'
 	if test $$CDB = "-MJ" ; then \
 		$(CC) $(CC_comp_flag) $(arch) $(cpp_flags) $(h5include) -I$(includedir) $(CDB) $@.json -o $@ $<; \
 	else \
@@ -289,7 +289,7 @@ $(OBJDIR)/${OUTPUTDIR}/%.o: %.cpp $(OBJDIR)/$(OUTPUTDIR)/%.d| $(OBJDIR)/$(OUTPUT
 # link *.o objects
 .PHONY: 
 $(BINDIR)/${OUTPUTDIR}/esp: $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj)) $(MODULES_SRC)/libphy_modules.a | $(BINDIR) $(RESDIR) $(BINDIR)/$(OUTPUTDIR)  $(OBJDIR)
-	@echo -e $(YELLOW)creating $@ $(END)
+	@echo -e '$(YELLOW)creating $@ $(END)'
 	$(CC) -o $(BINDIR)/$(OUTPUTDIR)/esp $(arch) $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj)) -L$(MODULES_SRC) -lphy_modules $(h5libdir) $(h5libs) $(link_flags)
 	if test $$CDB = "-MJ" ; then \
 	rm -f compile_commands.json; \
@@ -301,7 +301,7 @@ $(BINDIR)/${OUTPUTDIR}/esp: $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj)) $(MODULE
 # phony so that it will always be run
 .PHONY: symlink
 symlink: $(BINDIR)/$(OUTPUTDIR)/esp
-	@echo -e $(BLUE)make link from $(BINDIR)/$(OUTPUTDIR)/esp to $(BINDIR)/esp  $(END)
+	@echo -e '$(BLUE)make link from $(BINDIR)/$(OUTPUTDIR)/esp to $(BINDIR)/esp  $(END)'
 	rm -f $(BINDIR)/esp
 	ln -s $(BINDIR)/$(OUTPUTDIR)/esp -r -t bin
 
@@ -312,7 +312,7 @@ export
 # always call submakefile for modules
 .PHONY: $(MODULES_SRC)/libphy_modules.a
 $(MODULES_SRC)/libphy_modules.a:
-	@echo -e $(MAGENTA)Creating physics module from subdir $(MODULES_SRC)$(END)
+	@echo -e '$(MAGENTA)Creating physics module from subdir $(MODULES_SRC)$(END)'
 	$(MAKE) -f Makefile -C $(MODULES_SRC)
 
 #######################################################################
@@ -325,53 +325,53 @@ $(MODULES_SRC)/libphy_modules.a:
 tests: ${BINDIR}/${TESTDIR}/cmdargs_test ${BINDIR}/${TESTDIR}/config_test ${BINDIR}/${TESTDIR}/storage_test ${BINDIR}/${TESTDIR}/directories_test ${BINDIR}/${TESTDIR}/gen_init  ${BINDIR}/${TESTDIR}/reduction_add_test
 
 $(BINDIR)/$(TESTDIR)/cmdargs_test:  $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj_tests_cmdargs)) | $(BINDIR)/${OUTPUTDIR} $(BINDIR)/$(TESTDIR) $(BINDIR) $(RESDIR)
-	@echo -e $(YELLOW)creating $@ $(END)
+	@echo -e '$(YELLOW)creating $@ $(END)'
 	$(CC) $(arch) $(link_flags) -o $(BINDIR)/$(TESTDIR)/cmdargs_test $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj_tests_cmdargs))
 
 $(BINDIR)/$(TESTDIR)/config_test:  $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj_tests_config)) | $(BINDIR)/${OUTPUTDIR} $(BINDIR)/$(TESTDIR) $(BINDIR) $(RESDIR)
-	@echo -e $(YELLOW)creating $@ $(END)
+	@echo -e '$(YELLOW)creating $@ $(END)'
 	$(CC)  $(arch) $(link_flags) -o $(BINDIR)/$(TESTDIR)/config_test $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj_tests_config))
 
 $(BINDIR)/$(TESTDIR)/directories_test:  $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj_tests_directories)) | $(BINDIR)/${OUTPUTDIR} $(BINDIR)/$(TESTDIR) $(BINDIR) $(RESDIR)
-	@echo -e $(YELLOW)creating $@ $(END)
+	@echo -e '$(YELLOW)creating $@ $(END)'
 	$(CC) $(arch) $(link_flags) -o $(BINDIR)/$(TESTDIR)/directories_test $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj_tests_directories))
 
 $(BINDIR)/$(TESTDIR)/storage_test:  $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj_tests_storage)) | $(BINDIR)/${OUTPUTDIR} $(BINDIR)/$(TESTDIR) $(BINDIR) $(RESDIR)
-	@echo -e $(YELLOW)creating $@ $(END)
+	@echo -e '$(YELLOW)creating $@ $(END)'
 	$(CC) $(arch) $(link_flags) -o $(BINDIR)/$(TESTDIR)/storage_test $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj_tests_storage))  $(h5libdir) $(h5libs)
 
 $(BINDIR)/$(TESTDIR)/gen_init:  $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj_tests_gen_init)) | $(BINDIR)/${OUTPUTDIR} $(BINDIR)/$(TESTDIR) $(BINDIR) $(RESDIR)
-	@echo -e $(YELLOW)creating $@ $(END)
+	@echo -e '$(YELLOW)creating $@ $(END)'
 	$(CC) $(arch) $(link_flags) -o $(BINDIR)/$(TESTDIR)/gen_init $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj_tests_gen_init))  $(h5libdir) $(h5libs)
 
 $(BINDIR)/$(TESTDIR)/reduction_add_test:  $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj_tests_reduction_add)) | $(BINDIR)/${OUTPUTDIR} $(BINDIR)/$(TESTDIR) $(BINDIR) $(RESDIR)
-	@echo -e $(YELLOW)creating $@ $(END)
+	@echo -e '$(YELLOW)creating $@ $(END)'
 	$(CC) $(arch) $(link_flags) -o $(BINDIR)/$(TESTDIR)/reduction_add_test $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj_tests_reduction_add))  $(h5libdir) $(h5libs)
 
 #######################################################################
 # Cleanup
 .phony: clean,ar
 clean:
-	@echo -e $(CYAN)clean up binaries $(END)
+	@echo -e '$(CYAN)clean up binaries $(END)'
 	-$(RM) $(BINDIR)/debug/esp
 	-$(RM) $(BINDIR)/release/esp
 	-$(RM) $(BINDIR)/prof/esp
-	@echo -e $(CYAN)clean up objects files and dependencies $(END)
+	echo -e '$(CYAN)clean up objects files and dependencies $(END)'
 	-$(RM) $(OBJDIR)/debug/*.o $(OBJDIR)/debug/*.d $(OBJDIR)/debug/*.d.* $(OBJDIR)/debug/*.o.json
 	-$(RM) $(OBJDIR)/release/*.o $(OBJDIR)/release/*.d $(OBJDIR)/release/*.d.* $(OBJDIR)/release/*.o.json
 	-$(RM) $(OBJDIR)/prof/*.o $(OBJDIR)/prof/*.d $(OBJDIR)/prof/*.d.* $(OBJDIR)/prof/*.o.json
-	@echo -e $(CYAN)clean up tests binaries $(END)
+	@echo -e '$(CYAN)clean up tests binaries $(END)'
 	-$(RM) $(BINDIR)/tests/cmdargs_test
 	-$(RM) $(BINDIR)/tests/storage_test
 	-$(RM) $(BINDIR)/tests/config_test
 	-$(RM) $(BINDIR)/tests/directories_test
 	-$(RM) $(BINDIR)/tests/gen_init
 	-$(RM) $(BINDIR)/tests/test_reduction_add
-	@echo -e $(CYAN)clean up symlink $(END)
+	@echo -e '$(CYAN)clean up symlink $(END)'
 	-$(RM) $(BINDIR)/esp
-	@echo -e $(CYAN)clean up modules directory $(END)
+	@echo -e '$(CYAN)clean up modules directory $(END)'
 	$(MAKE) -C $(MODULES_SRC) clean
-	@echo -e $(CYAN)clean up directories $(END)
+	@echo -e '$(CYAN)clean up directories $(END)'
 	-$(RM) -d $(BINDIR)/debug $(BINDIR)/release $(BINDIR)/prof
 	-$(RM) -d $(BINDIR)/tests
 	-$(RM) -d $(OBJDIR)/debug

--- a/Makefile
+++ b/Makefile
@@ -258,18 +258,8 @@ versionfile: | $(OBJDIR)
 	@echo -n "#define GIT_HASH_RAW " >> $(GITREV_FILE)
 	@echo \"$(shell git describe --always --dirty --abbrev=40 --match="NoTagWithThisName")\" >> $(GITREV_FILE)
 
-
-
 # for CUDA files
-# $(OBJDIR)/${OUTPUTDIR}/esp.d: esp.cu versionfile | $(OBJDIR)/$(OUTPUTDIR) $(OBJDIR) 
-# 	@echo -e '$(BLUE)computing dependencies $@ $(END)'
-# 	set -e; rm -f $@; \
-# 	$(CC) $(dependencies_flags) $(arch) $(cuda_dep_flags) $(h5include) -I$(includedir) -I$(OBJDIR) $< > $@.$$$$; \
-# 	sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' < $@.$$$$ > $@; \
-# 	rm -f $@.$$$$
-
-# for CUDA files
-$(OBJDIR)/${OUTPUTDIR}/%.d: %.cu | $(OBJDIR)/$(OUTPUTDIR) $(OBJDIR)
+$(OBJDIR)/${OUTPUTDIR}/%.d: %.cu | $(OBJDIR)/$(OUTPUTDIR) $(OBJDIR) versionfile
 	@echo -e '$(BLUE)computing dependencies $@ $(END)'
 	set -e; rm -f $@; \
 	$(CC) $(dependencies_flags) $(arch) $(cuda_dep_flags) $(h5include) -I$(includedir)  -I$(OBJDIR)  $< > $@.$$$$; \

--- a/mjolnir/hamarr.py
+++ b/mjolnir/hamarr.py
@@ -162,6 +162,8 @@ class output_new:
             outputs['F_net'] = 'f_net'
             outputs['Alf_Qheat'] = 'TSqheat'
             outputs['col_mu_star'] = 'mustar'
+            outputs['F_up_TOA_spectrum'] = 'spectrum'
+            outputs['lambda_wave'] = 'wavelength'
 
         for t in np.arange(ntsi - 1, nts, stride):
             fileh5 = resultsf + '/esp_output_' + simID + '_' + np.str(t + 1) + '.h5'
@@ -262,6 +264,8 @@ class output_new:
                     elif key == 'tau':
                         self.tau_sw = np.reshape(data[::2],(grid.point_num,grid.nv,tlen))
                         self.tau_lw = np.reshape(data[1::2],(grid.point_num,grid.nv,tlen))
+                    elif key == 'spectrum':
+                        self.spectrum = np.reshape(data, (grid.point_num,-1,tlen))
                     else:
                         setattr(self, key, data)
                 else:
@@ -2204,3 +2208,90 @@ def RTbalance(input, grid, output):
     # not finished!
     asr = fsw_dn[:, input.nv - 1, :] * grid.areasT[:, None]
     olr = flw_up[:, input.nv - 1, :] * grid.areasT[:, None]
+
+def spectrum(input, grid, output, z, stride=20, axis=None, save=True):
+    output.load_reshape(grid, ['spectrum'])
+    # get figure and axis
+    if isinstance(axis, axes.SubplotBase):
+        ax = axis
+        fig = plt.gcf()
+    elif (isinstance(axis, tuple)
+          and isinstance(axis[0], plt.Figure)
+          and isinstance(axis[1], axes.SubplotBase)):
+        fig = axis[0]
+        ax = axis[1]
+    elif axis is None:
+        fig, ax = plt.subplots(1, 1, figsize=(5, 4))
+    else:
+        raise IOError("'axis = {}' but {} is neither an axes.SubplotBase instance nor a (axes.SubplotBase, plt.Figure) instance".format(axis, axis))
+
+    fig.set_tight_layout(True)
+    
+    tsp = output.nts - output.ntsi + 1
+
+    
+    col_lon = []
+    col_lat = []
+    col_lor = []
+    
+    for column in np.arange(0, grid.point_num, stride):
+        lamda = output.wavelength[:]*1e6
+        if tsp > 1:
+            spectrum= np.mean(output.spectrum[column, :, :], axis=1)
+        else:
+            spectrum= output.spectrum[column, :, 0]
+
+        #color = hsv_to_rgb([column / grid.point_num, 1.0, 1.0])
+        lon = grid.lon[column]
+        lat = grid.lat[column]
+        lon_norm = lon / (2.0 * math.pi)
+        lat_norm = lat / (math.pi / 2.0)
+        if lat > 0.0:
+            color = hsv_to_rgb([lon_norm, 1.0 - 0.7 * lat_norm, 1.0])
+        else:
+            color = hsv_to_rgb([lon_norm, 1.0, 1.0 + 0.7 * lat_norm])
+
+        col_lon.append(lon)
+        col_lat.append(lat)
+        col_lor.append(color)
+        ax.plot(lamda, spectrum, 'k-', alpha=0.5, lw=1.0,
+                    path_effects=[pe.Stroke(linewidth=1.5, foreground=color), pe.Normal()])
+
+        
+    # add an insert showing the position of columns
+    inset_pos = [0.8, 0.1, 0.18, 0.18]
+    ax_inset = ax.inset_axes(inset_pos)
+    ax_inset.scatter(col_lon, col_lat, c=col_lor, s=1.0)
+    ax_inset.tick_params(axis='both',
+                         which='both',
+                         top=False,
+                         bottom=False,
+                         left=False,
+                         right=False,
+                         labelright=False,
+                         labelleft=False,
+                         labeltop=False,
+                         labelbottom=False)
+
+    # plt.plot(Tad,P/100,'r--')
+    #ax.invert_yaxis()
+    ax.set_xscale('log')
+    ax.set_yscale('linear')
+    ax.set_ylabel('Flux (W m^2)')
+    ax.set_xlabel('Wavelength [um]')
+    ax.set_title('Time = %#.3f - %#.3f days' % (output.time[0], output.time[-1]))
+
+    pfile = None
+    if save == True:
+        output_path = pathlib.Path(input.resultsf) / 'figures'
+        if not output_path.exists():
+            output_path.mkdir()
+
+        fname = f"spectrum_i{output.ntsi}_l{output.nts}"
+        pfile = output_path / (fname.replace(".", "+") + '.pdf')
+        plt.savefig(pfile)
+
+        plt.close()
+        pfile = str(pfile)
+
+    return pfile

--- a/mjolnir/mjolnir_plot_helper.py
+++ b/mjolnir/mjolnir_plot_helper.py
@@ -30,11 +30,12 @@ def call_plot(name, func, *args, **kwargs):
         pfile = func(*args,**kwargs)
         if pfile is not None:
             print('Created file: ' + str(pfile))
+        return pfile
     except:
         print(traceback.format_exc())
         print(f'{name} plot FAILED')
+        return None
 
-    return pfile
 
 def make_plot(args, save=True, axis=None):
     pview = args.pview
@@ -50,6 +51,7 @@ def make_plot(args, save=True, axis=None):
              'DGfutprof', 'DGfdtprof', 'DGfnetprof', 'mustar', 'DGfuptot', 'DGfdowntot', 'DGfnet', 'DGqheat',  # alf stuff
              'TSfutprof', 'TSfdtprof', 'TSfnetprof', 'mustar', 'TSfuptot', 'TSfdowntot', 'TSfnet', 'TSqheat',
              'DGqheatprof', 'TSqheatprof', 'qheatprof',
+             'spectrum',
              'phase','all']
 
     rg_needed = ['Tver', 'Tlonver', 'uver', 'ulonver', 'vver', 'wver', 'wlonver', 'Tulev', 'PTver', 'PTlonver', 'ulev', 'PVver', 'PVlev',
@@ -478,6 +480,12 @@ def make_plot(args, save=True, axis=None):
              'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
         pfile = call_plot('mustar',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
         plots_created.append(pfile)
+
+    if ('spectrum' in pview) and (input.TSRT):
+        z = {'label': r'spectrum ', 'name': 'spectrum',
+             'cmap': 'magma', 'mt': maketable}
+        pfile = call_plot('spectrum',ham.spectrum, input, grid, output, z, save=save, axis=axis)
+        plots_created.append(pfile)   
 
     # --- Pressure profile types-------------------------------
     if 'TP' in pview or 'all' in pview:

--- a/mjolnir/mjolnyr.ipynb
+++ b/mjolnir/mjolnyr.ipynb
@@ -8,19 +8,33 @@
    "source": [
     "# All configs\n",
     "\n",
-    "data_path = \"../spunup_tsrt_r50/\"\n",
+    "data_path = \"../Alfrodull/experiments/ubelix/wigl/rt_noniso_p5e7_Tint500K/\"\n",
+    "#data_path = \"../aw_rt_iso_p15e7_c/\"\n",
     "\n",
-    "output_path = \"../spunup_tsrt_r50/report\"\n",
+    "#data_path = \"../Alfrodull/experiments/ubelix/noniso_thomas_p5e7/\"\n",
+    "#data_path = \"../alf_noniso_thomas_p5e7/\"\n",
     "\n",
     "# path to mjolnir from execution directory, used if ran in another folder, e.g. with 'muninn' script\n",
     "mjolnir_path = \"./\"\n",
     "\n",
-    "FIGSIZE_x = 10\n",
-    "FIGSIZE_y = 7\n",
+    "FIGSIZE_x = 15\n",
+    "FIGSIZE_y = 12\n",
     "\n",
     "VIDEO_x = 1280\n",
     "VIDEO_DISPLAY_x = 800\n",
-    "dpi = 296"
+    "dpi = 296\n",
+    "\n",
+    "regrided_plots = False\n",
+    "\n",
+    "movies = False\n",
+    "\n",
+    "quad_plots = True\n",
+    "\n",
+    "single_plot = True\n",
+    "\n",
+    "plot_last = True\n",
+    "\n",
+    "plot_index = 1\n"
    ]
   },
   {
@@ -61,9 +75,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "try:\n",
+    "    output_path = pathlib.Path(output_path)\n",
+    "except:\n",
+    "    output_path = pathlib.Path(data_path) / f\"report/\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "exp_path = pathlib.Path(data_path) \n",
-    "output_dir = pathlib.Path(output_path)\n",
-    "\n",
+    "output_dir = output_path\n",
     "FIGSIZE = (FIGSIZE_x, FIGSIZE_y)\n",
     "\n"
    ]
@@ -192,8 +217,17 @@
     "print(f\"First index: {first_idx}\")\n",
     "print(f\"Last index: {last_idx}\")\n",
     "\n",
+    "print()\n",
+    "print(\"Plotting\")\n",
+    "print(\"========\")\n",
+    "print()\n",
+    "print(f\"Plot quad: {quad_plots}\")\n",
+    "print(f\"Plot single plot: {single_plot}\")\n",
+    "print(f\"Plot last: {plot_last}\")\n",
     "\n",
-    "\n"
+    "if plot_last:\n",
+    "    plot_index = last_idx\n",
+    "print(f\"plot_index: {plot_index}\" )\n"
    ]
   },
   {
@@ -210,7 +244,7 @@
     "\n",
     "args.pview = [\"fuptot\"]\n",
     "args.file = [str(exp_path)]\n",
-    "args.simulation_ID = [\"auto\"]\n",
+    "args.simulation_ID = [planet_name]\n",
     "args.initial_file = [file_idx]\n",
     "args.last_file = [file_idx]\n",
     "args.horizontal_lev = [2.5e2]\n",
@@ -337,7 +371,7 @@
     "\n",
     "    mph.make_plot(args, False, axis=(fig, ax_first))\n",
     "    ttl = ax_first.get_title()\n",
-    "    ax_first.set_title(ttl + \"\\n\" + \"Initial (idx=0)\")\n",
+    "    ax_first.set_title(ttl + \"\\n\" + f\"Initial (idx={i})\")\n",
     "\n",
     "    i = last_idx\n",
     "    args.pview = [plot_type]\n",
@@ -349,7 +383,7 @@
     "    ttl = ax_last.get_title()\n",
     "    ax_last.set_title(ttl + \"\\n\" + f\"Last (idx={i})\")\n",
     "\n",
-    "    i = 1\n",
+    "    i = first_idx + 1\n",
     "    args.pview = [plot_type]\n",
     "    args.initial_file = [i]\n",
     "    args.last_file = [i]\n",
@@ -357,9 +391,9 @@
     "\n",
     "    mph.make_plot(args, False, axis=(fig, ax_second))\n",
     "    ttl = ax_second.get_title()\n",
-    "    ax_second.set_title(ttl + \"\\n\" + \"First step (idx=1)\")\n",
+    "    ax_second.set_title(ttl + \"\\n\" + f\"First step (idx={i})\")\n",
     "\n",
-    "    i = (last_idx - first_idx) // 2\n",
+    "    i = (last_idx + first_idx) // 2\n",
     "    args.pview = [plot_type]\n",
     "    args.initial_file = [i]\n",
     "    args.last_file = [i]\n",
@@ -368,6 +402,45 @@
     "    mph.make_plot(args, False, axis=(fig, ax_mid))\n",
     "    ttl = ax_mid.get_title()\n",
     "    ax_mid.set_title(ttl + \"\\n\" + f\"Middle step (idx={i})\")\n",
+    "    \n",
+    "    return fig\n",
+    "\n",
+    "\n",
+    "def plot_single(plot_type, plot_idx, args):\n",
+    "    #fig, ((ax_first, ax_last), (ax_second, ax_mid)) = plt.subplots(\n",
+    "    #    2, 2, figsize=FIGSIZE\n",
+    "    #)\n",
+    "    i = plot_idx\n",
+    "    stride = 1\n",
+    "    overwrite = False\n",
+    "    args.pgrid_ref = [f\"pgrid_{i}_{i}_1.txt\"]\n",
+    "    \n",
+    "    \n",
+    "    \n",
+    "    pgrid_ref = exp_path / args.pgrid_ref[0]\n",
+    "    if pgrid_ref.exists():\n",
+    "        pass\n",
+    "    else:\n",
+    "        ham.define_Pgrid(\n",
+    "        args.file[0],\n",
+    "        planet_name,\n",
+    "        args.initial_file[0],\n",
+    "        args.last_file[0],\n",
+    "        stride,\n",
+    "        overwrite=overwrite,\n",
+    "        )\n",
+    "    fig = plt.Figure(figsize=FIGSIZE)\n",
+    "    ax = fig.subplots(1,1)\n",
+    "\n",
+    "    \n",
+    "    args.pview = [plot_type]\n",
+    "    args.initial_file = [i]\n",
+    "    args.last_file = [i]\n",
+    "\n",
+    "    mph.make_plot(args, False, axis=(fig, ax))\n",
+    "    ttl = ax.get_title()\n",
+    "    ax.set_title(ttl + \"\\n\" + f\"idx={i}\")\n",
+    "\n",
     "    \n",
     "    return fig"
    ]
@@ -420,6 +493,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Mu Star"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#plot_steps(\"mustar\", first_idx, last_idx, args)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# TP Profile"
    ]
   },
@@ -429,7 +518,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_anim(\"TP\", \"TP_anim.mp4\", first_idx, last_idx, args)"
+    "pa = None\n",
+    "if movies:\n",
+    "    pa = plot_anim(\"TP\", \"TP_anim.mp4\", first_idx, last_idx, args)\n",
+    "pa"
    ]
   },
   {
@@ -438,7 +530,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_steps(\"TP\", first_idx, last_idx, args)"
+    "f = None\n",
+    "if quad_plots:\n",
+    "    f = plot_steps(\"TP\", first_idx, last_idx, args)\n",
+    "f"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f = None\n",
+    "if plot_single:\n",
+    "    f = plot_single(\"TP\", plot_index, args)\n",
+    "f"
    ]
   },
   {
@@ -454,7 +561,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_anim(\"Tver\", \"Tver_anim.mp4\", first_idx, last_idx, args)"
+    "pa = None\n",
+    "if movies and regrided_plots:\n",
+    "    pa = plot_anim(\"Tver\", \"Tver_anim.mp4\", first_idx, last_idx, args)\n",
+    "pa"
    ]
   },
   {
@@ -463,7 +573,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_steps(\"Tver\", first_idx, last_idx, args)"
+    "f = None\n",
+    "if quad_plots and regrided_plots:\n",
+    "    f = plot_steps(\"Tver\", first_idx, last_idx, args)\n",
+    "f"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f = None\n",
+    "if plot_single:\n",
+    "    f = plot_single(\"Tver\", plot_index, args)\n",
+    "f"
    ]
   },
   {
@@ -479,7 +604,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_anim(\"Tlonver\", \"Tlonver_anim.mp4\", first_idx, last_idx, args)"
+    "pa = None\n",
+    "if movies and regrided_plots:\n",
+    "    pa = plot_anim(\"Tlonver\", \"Tlonver_anim.mp4\", first_idx, last_idx, args)\n",
+    "pa\n"
    ]
   },
   {
@@ -488,7 +616,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_steps(\"Tlonver\", first_idx, last_idx, args)"
+    "f = None\n",
+    "if regrided_plots and quad_plots:\n",
+    "    f = plot_steps(\"Tlonver\", first_idx, last_idx, args)\n",
+    "f"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f = None\n",
+    "if plot_single:\n",
+    "    f = plot_single(\"Tlonver\", plot_index, args)\n",
+    "f"
    ]
   },
   {
@@ -504,7 +647,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_anim(\"uver\", \"uver_anim.mp4\", first_idx, last_idx, args)"
+    "if movies and regrided_plots:\n",
+    "    plot_anim(\"uver\", \"uver_anim.mp4\", first_idx, last_idx, args)"
    ]
   },
   {
@@ -513,7 +657,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_steps(\"uver\", first_idx, last_idx, args)"
+    "f = None\n",
+    "if quad_plots and regrided_plots:\n",
+    "    f = plot_steps(\"uver\", first_idx, last_idx, args)\n",
+    "f"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f = None\n",
+    "if plot_single:\n",
+    "    f = plot_single(\"uver\", plot_index, args)\n",
+    "f"
    ]
   },
   {
@@ -549,7 +708,7 @@
    "outputs": [],
    "source": [
     "pa = None\n",
-    "if has_TSRT:\n",
+    "if has_TSRT and movies and regrided_plots:\n",
     "    pa = plot_anim(\"qheat\", \"qheat_anim.mp4\", first_idx, last_idx, args)\n",
     "    \n",
     "pa"
@@ -561,8 +720,109 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if has_TSRT:\n",
-    "    plot_steps(\"qheat\", first_idx, last_idx, args)"
+    "f = None\n",
+    "if has_TSRT and quad_plots and regrided_plots:\n",
+    "    f = plot_steps(\"qheat\", first_idx, last_idx, args)\n",
+    "f"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f = None\n",
+    "if has_TSRT and plot_single:\n",
+    "    f = plot_single(\"qheat\", plot_index, args)\n",
+    "f"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pa = None\n",
+    "if has_TSRT and movies:\n",
+    "    pa = plot_anim(\"qheatprof\", \"qheatprof_anim.mp4\", first_idx, last_idx, args)\n",
+    "    \n",
+    "pa"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f = None\n",
+    "if has_TSRT and quad_plots:\n",
+    "    f = plot_steps(\"qheatprof\", first_idx, last_idx, args)\n",
+    "f"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f = None\n",
+    "if has_TSRT and plot_single:\n",
+    "    f = plot_single(\"qheatprof\", plot_index, args)\n",
+    "f"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pa = None\n",
+    "if has_TSRT and movies:\n",
+    "    pa = plot_anim(\"TSqheatprof\", \"TSqheatprof_anim.mp4\", first_idx, last_idx, args)\n",
+    "    \n",
+    "pa"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f = None\n",
+    "if has_TSRT and quad_plots:\n",
+    "    f = plot_steps(\"TSqheatprof\", first_idx, last_idx, args)\n",
+    "f"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f = None\n",
+    "if has_TSRT and plot_single:\n",
+    "    f = plot_single(\"DGqheatprof\", plot_index, args)\n",
+    "f"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pa = None\n",
+    "if has_TSRT and has_RT and movies:\n",
+    "    pa = plot_anim(\"DGqheatprof\", \"DGqheatprof_anim.mp4\", first_idx, last_idx, args)\n",
+    "    \n",
+    "pa"
    ]
   },
   {
@@ -581,7 +841,7 @@
    "outputs": [],
    "source": [
     "pa = None\n",
-    "if has_TSRT:\n",
+    "if has_TSRT and movies:\n",
     "    pa = plot_anim(\"TSfutprof\", \"futprof_anim.mp4\", first_idx, last_idx, args)\n",
     "\n",
     "pa"
@@ -593,8 +853,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if has_TSRT:\n",
-    "    plot_steps(\"TSfutprof\", first_idx, last_idx, args)"
+    "f = None\n",
+    "if has_TSRT and quad_plots:\n",
+    "    f = plot_steps(\"TSfutprof\", first_idx, last_idx, args)\n",
+    "f"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f = None\n",
+    "if has_TSRT and plot_single:\n",
+    "    f = plot_single(\"TSfutprof\", plot_index, args)\n",
+    "f"
    ]
   },
   {
@@ -611,7 +885,10 @@
    "outputs": [],
    "source": [
     "pa = None\n",
-    "if has_TSRT:\n",
+    "\n",
+    "args.horizontal_lev = [1e-2]\n",
+    "\n",
+    "if has_TSRT and movies and regrided_plots:\n",
     "    pa = plot_anim(\"TSfuptot\", \"fuptot_anim.mp4\", first_idx, last_idx, args)\n",
     "    \n",
     "pa"
@@ -623,8 +900,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if has_TSRT:\n",
-    "    plot_steps(\"TSfuptot\", first_idx, last_idx, args)"
+    "f = None\n",
+    "if has_TSRT and quad_plots and regrided_plots:\n",
+    "    f = plot_steps(\"TSfuptot\", first_idx, last_idx, args)\n",
+    "    \n",
+    "f"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f = None\n",
+    "if has_TSRT and plot_single:\n",
+    "    f = plot_single(\"TSfuptot\", plot_index, args)\n",
+    "f"
    ]
   },
   {
@@ -643,7 +935,7 @@
    "outputs": [],
    "source": [
     "pa = None\n",
-    "if has_TSRT:\n",
+    "if has_TSRT and movies:\n",
     "    pa = plot_anim(\"TSfdtprof\", \"fdtprof_anim.mp4\", first_idx, last_idx, args)\n",
     "    \n",
     "pa"
@@ -655,8 +947,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if has_TSRT:\n",
-    "    plot_steps(\"TSfdtprof\", first_idx, last_idx, args)"
+    "f = None\n",
+    "if has_TSRT and quad_plots:\n",
+    "    f = plot_steps(\"TSfdtprof\", first_idx, last_idx, args)\n",
+    "f\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f = None\n",
+    "if has_TSRT and plot_single:\n",
+    "    f = plot_single(\"TSfdtprof\", plot_index, args)\n",
+    "f"
    ]
   },
   {
@@ -673,7 +979,7 @@
    "outputs": [],
    "source": [
     "pa = None\n",
-    "if has_TSRT:\n",
+    "if has_TSRT and movies and regrided_plots:\n",
     "    pa = plot_anim(\"TSfdowntot\", \"fdowntot_anim.mp4\", first_idx, last_idx, args)\n",
     "    \n",
     "pa"
@@ -685,8 +991,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if has_TSRT:\n",
-    "    plot_steps(\"TSfdowntot\", first_idx, last_idx, args)"
+    "f = None\n",
+    "if has_TSRT and quad_plots and regrided_plots:\n",
+    "    f = plot_steps(\"TSfdowntot\", first_idx, last_idx, args)\n",
+    "f"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f = None\n",
+    "if has_TSRT and plot_single:\n",
+    "    f = plot_single(\"TSfdowntot\", plot_index, args)\n",
+    "f"
    ]
   },
   {
@@ -706,8 +1026,8 @@
    "source": [
     "pa = None \n",
     "\n",
-    "if has_TSRT:\n",
-    "    pa = plot_anim(\"TSfnetprof\", \"fnetprof_anim.mp4\", first_idx, last_idx, args)\n",
+    "if has_TSRT and movies:\n",
+    "    pa = plot_anim(\"TSfluxprof\", \"fluxprof_anim.mp4\", first_idx, last_idx, args)\n",
     "    \n",
     "pa"
    ]
@@ -718,8 +1038,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if has_TSRT:\n",
-    "    plot_steps(\"TSfnetprof\", first_idx, last_idx, args)"
+    "f = None\n",
+    "if has_TSRT and quad_plots:\n",
+    "    f = plot_steps(\"TSfluxprof\", first_idx, last_idx, args)\n",
+    "f"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f = None\n",
+    "if has_TSRT and plot_single:\n",
+    "    f = plot_single(\"TSfluxprof\", plot_index, args)\n",
+    "f"
    ]
   },
   {
@@ -736,8 +1070,8 @@
    "outputs": [],
    "source": [
     "pa = None\n",
-    "if has_TSRT:\n",
-    "    pa = plot_anim(\"TSfnet\", \"fnet_anim.mp4\", first_idx, last_idx, args)\n",
+    "if has_TSRT and movies and regrided_plots:\n",
+    "    pa = plot_anim(\"TSfnet\", \"TSfnet_anim.mp4\", first_idx, last_idx, args)\n",
     "    \n",
     "pa"
    ]
@@ -748,8 +1082,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if has_TSRT:\n",
-    "    plot_steps(\"TSfnet\", first_idx, last_idx, args)"
+    "f = None\n",
+    "if has_TSRT and quad_plots and regrided_plots:\n",
+    "    f = plot_steps(\"TSfluxprof\", first_idx, last_idx, args)\n",
+    "f"
    ]
   },
   {
@@ -757,7 +1093,12 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "f = None\n",
+    "if has_TSRT and plot_single:\n",
+    "    f = plot_single(\"TSfluxprof\", plot_index, args)\n",
+    "f"
+   ]
   },
   {
    "cell_type": "code",
@@ -783,7 +1124,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/mjolnir/mjolnyr.ipynb
+++ b/mjolnir/mjolnyr.ipynb
@@ -8,11 +8,11 @@
    "source": [
     "# All configs\n",
     "\n",
-    "data_path = \"../Alfrodull/experiments/ubelix/wigl/rt_noniso_p5e7_Tint500K/\"\n",
-    "#data_path = \"../aw_rt_iso_p15e7_c/\"\n",
+    "#data_path = \"../Alfrodull/experiments/ubelix/wigl/rt_noniso_p5e7_Tint500K/\"\n",
+    "#data_path = \"../Alfrodull/experiments/ubelix/wigl/rt_iso_p2e7_Ts6000/\"\n",
+    "#data_path = \"../rtc_iso_p2e7/\"\n",
     "\n",
-    "#data_path = \"../Alfrodull/experiments/ubelix/noniso_thomas_p5e7/\"\n",
-    "#data_path = \"../alf_noniso_thomas_p5e7/\"\n",
+    "data_path = \"../Alfrodull/experiments/ubelix/wigl/rt_noniso_p4e7/\"\n",
     "\n",
     "# path to mjolnir from execution directory, used if ran in another folder, e.g. with 'muninn' script\n",
     "mjolnir_path = \"./\"\n",
@@ -28,13 +28,15 @@
     "\n",
     "movies = False\n",
     "\n",
-    "quad_plots = True\n",
+    "quad_plots = False\n",
     "\n",
     "single_plot = True\n",
     "\n",
     "plot_last = True\n",
     "\n",
-    "plot_index = 1\n"
+    "plot_index = 1\n",
+    "\n",
+    "plot_spectrum = True\n"
    ]
   },
   {
@@ -1101,11 +1103,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Spectrum"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "f = None\n",
+    "if has_TSRT and plot_spectrum:\n",
+    "    f = plot_single(\"spectrum\", plot_index, args)\n",
+    "f"
+   ]
   }
  ],
  "metadata": {

--- a/src/ESP/thor_driver.cu
+++ b/src/ESP/thor_driver.cu
@@ -683,6 +683,11 @@ __host__ void ESP::Thor(const SimulationSetup& sim) {
                                                profx_Qheat_d,
                                                energy_equation);
         cudaDeviceSynchronize();
+        BENCH_POINT_I_S(current_step,
+                        rk,
+                        "Compute_Slow_Modes",
+                        (),
+                        ("SlowMh_d", "SlowWh_d", "SlowRho_d", "Slowpressure_d"))
         // Updates: SlowMh_d, SlowWh_d, SlowRho_d, Slowpressure_d
         Compute_Slow_Modes_Poles<6><<<2, 1>>>(SlowMh_d,
                                               SlowWh_d,
@@ -723,6 +728,7 @@ __host__ void ESP::Thor(const SimulationSetup& sim) {
                                               profx_dWh_d,
                                               profx_Qheat_d,
                                               energy_equation);
+        cudaDeviceSynchronize();
 
         BENCH_POINT_I_S(current_step,
                         rk,

--- a/src/ESP/thor_driver.cu
+++ b/src/ESP/thor_driver.cu
@@ -343,6 +343,13 @@ __host__ void ESP::Thor(const SimulationSetup& sim) {
                                                energy_equation);
             cudaDeviceSynchronize();
 
+            BENCH_POINT_I_S(current_step,
+                            rk,
+                            "Diffusion_Op1",
+                            (),
+                            ("diffmh_d", "diffw_d", "diffrh_d", "diffpr_d", "diff_d"))
+
+
             cudaMemset(diffrh_d, 0, sizeof(double) * point_num * nv);
             cudaMemset(boundary_flux_d, 0, sizeof(double) * 6 * point_num * nv);
             //Updates: diffmh_d, diffw_d, diffrh_d, diffpr_d, diff_d
@@ -409,7 +416,19 @@ __host__ void ESP::Thor(const SimulationSetup& sim) {
 
             cudaDeviceSynchronize();
 
+            BENCH_POINT_I_S(current_step,
+                            rk,
+                            "Diffusion_Op2",
+                            (),
+                            ("diffmh_d", "diffw_d", "diffrh_d", "diffpr_d", "diff_d"))
+
+
             Correct_Horizontal<<<NBALL, NTH>>>(diffmh_d, diffmv_d, func_r_d, point_num);
+
+            cudaDeviceSynchronize();
+
+            BENCH_POINT_I_S(
+                current_step, rk, "Correct_Horizontal", (), ("diffmh_d", "diffmv_d", "func_r_d"))
         }
 
         if (phy_modules_execute)
@@ -642,6 +661,30 @@ __host__ void ESP::Thor(const SimulationSetup& sim) {
             cudaDeviceSynchronize();
         }
 
+        BENCH_POINT_I_S(current_step,
+                        rk,
+                        "phy_before_slow_modews",
+                        (),
+                        ("Mhk_d",
+                         "Whk_d",
+                         "Rhok_d",
+                         "Adv_d",
+                         "DivM_d",
+                         "diffmh_d",
+                         "diffw_d",
+                         "diffrh_d",
+                         "diffpr_d",
+                         "diffmv_d",
+                         "diffwv_d",
+                         "diffrv_d",
+                         "diffprv_d",
+                         "pressurek_d",
+                         "h_d",
+                         "hh_d",
+                         "gtil_d",
+                         "Altitude_d",
+                         "Altitudeh_d",
+                         "Qheat_d"))
 
         // Updates: SlowMh_d, SlowWh_d, SlowRho_d, Slowpressure_d
         Compute_Slow_Modes<LN, LN><<<NB, NT>>>(SlowMh_d,

--- a/src/esp.cu
+++ b/src/esp.cu
@@ -86,6 +86,8 @@ using std::string;
 
 #include "reduction_min.h"
 
+#include "git-rev.h"
+
 enum e_sig { ESIG_NOSIG = 0, ESIG_SIGTERM = 1, ESIG_SIGINT = 2 };
 
 
@@ -224,6 +226,9 @@ int main(int argc, char** argv) {
 
     log::printf(" build level: %s\n", BUILD_LEVEL);
 
+    log::printf(" git branch: %s\n", GIT_BRANCH_RAW);
+    log::printf(" git hash: %s\n", GIT_HASH_RAW);
+    
 
     //*****************************************************************
     // Initial conditions

--- a/src/esp.cu
+++ b/src/esp.cu
@@ -1279,9 +1279,9 @@ int main(int argc, char** argv) {
 
         // Run pressure check
         double pressure_min = gpu_min_on_device<1024>(X.pressure_d, X.point_num * X.nv);
-        log::printf("\n min pressure : %g\n", pressure_min);
+        log::printf("\n min pressure : %g Pa\n", pressure_min);
         if (pressure_min < pressure_check_limit) {
-            log::printf("\n min pressure lower than min pressure limit: %g\n", pressure_min);
+            log::printf("\n WARNING: min pressure lower than min pressure limit: %g Pa\n", pressure_min);
             if (exit_on_low_pressure_warning)
                 break;
         }

--- a/src/headers/binary_test.h
+++ b/src/headers/binary_test.h
@@ -134,7 +134,7 @@
 #else // do nothing
 #    define USE_BENCHMARK()
 #    define SET_BENCHMARK_PATH(path)
-#    define INIT_BENCHMARK(esp, grid, path)
+#    define INIT_BENCHMARK(esp, grid, path, write, compare)
 #    define BENCH_POINT(iteration, name, in, out)
 #    define BENCH_POINT_I(iteration, name, in, out)
 #    define BENCH_POINT_I_S(iteration, subiteration, name, in, out)

--- a/src/headers/binary_test.h
+++ b/src/headers/binary_test.h
@@ -61,8 +61,6 @@
 // precompiler macros to enable binary testing of simulation output
 // BENCHMARKING enables the binary testing. if not set, those
 // functions are empty and ignored by the compiler.
-// BENCH_POINT_WRITE enables writing data out to reference files
-// BENCH_POINT_COMPARE enables comparing current value with reference files
 
 #ifdef BENCHMARKING
 #    define BRACED_INIT_LIST(...) \
@@ -70,9 +68,11 @@
 #    define USE_BENCHMARK() binary_test& btester = binary_test::get_instance();
 #    define SET_BENCHMARK_PATH(path) \
         binary_test& btester = binary_test::get_instance().set_output("bindata_", path);
-#    define INIT_BENCHMARK(esp, grid, path)                                           \
+#    define INIT_BENCHMARK(esp, grid, path, write, compare)                           \
         binary_test::get_instance().append_definitions(build_definitions(esp, grid)); \
-        binary_test::get_instance().set_output("bindata_", path);
+        binary_test::get_instance().set_output("bindata_", path);                     \
+        binary_test::get_instance().set_write(write);                                 \
+        binary_test::get_instance().set_compare(compare);
 #    define BENCH_POINT(iteration, name, in, out)                          \
         btester.check_data(iteration,                                      \
                            name,                                           \
@@ -125,10 +125,10 @@
                            std::vector<std::string>(BRACED_INIT_LIST in),                       \
                            std::vector<std::string>(BRACED_INIT_LIST out),                      \
                            true);
-#    define BENCH_POINT_REGISTER_PHY_VARS(vars, in, out)                                        \
-        btester.register_phy_modules_variables(vars,			                        \
-                           std::vector<std::string>(BRACED_INIT_LIST in),                       \
-                           std::vector<std::string>(BRACED_INIT_LIST out)                      );
+#    define BENCH_POINT_REGISTER_PHY_VARS(vars, in, out)                                      \
+        btester.register_phy_modules_variables(vars,                                          \
+                                               std::vector<std::string>(BRACED_INIT_LIST in), \
+                                               std::vector<std::string>(BRACED_INIT_LIST out));
 
 
 #else // do nothing
@@ -144,7 +144,7 @@
 #    define BENCH_POINT_I_PHY(iteration, name, in, out)
 #    define BENCH_POINT_I_S_PHY(iteration, subiteration, name, in, out)
 #    define BENCH_POINT_I_SS_PHY(iteration, subiteration, subsubiteration, name, in, out)
-#    define BENCH_POINT_REGISTER_PHY_VARS(vars, in, out)                                        
+#    define BENCH_POINT_REGISTER_PHY_VARS(vars, in, out)
 #endif // BENCHMARKING
 
 #ifdef BENCHMARKING
@@ -231,6 +231,13 @@ public:
                                         const vector<string>&               phy_modules_data_in,
                                         const vector<string>&               phy_modules_data_out);
 
+    void set_compare(bool b) {
+        use_compare = b;
+    };
+    void set_write(bool b) {
+        use_write = b;
+    };
+
 private:
     vector<string> phy_modules_data_in;
     vector<string> phy_modules_data_out;
@@ -242,6 +249,8 @@ private:
     string output_crash;
     string output_base_name;
 
+    bool use_write   = false;
+    bool use_compare = false;
 
     // make constructor private, can only be instantiated through get_instance
     binary_test(string output_dir, string output_base_name);

--- a/src/headers/cuda_device_memory.h
+++ b/src/headers/cuda_device_memory.h
@@ -172,9 +172,13 @@ public:
 
     // zero out device memory
     bool zero() {
-
+      if (device_ptr != nullptr && size > 0)
+	{
         cudaError_t ret = cudaMemset(device_ptr, 0, sizeof(T) * size);
         return ret == cudaSuccess;
+	}
+      else
+	return true;
     };
 
     // copy data from device to local member array

--- a/src/headers/debug.h
+++ b/src/headers/debug.h
@@ -51,9 +51,9 @@
 // ***************************************
 // * binary comparison
 // compare benchmark point to references
-// #define BENCH_POINT_COMPARE
+// use --bincompare option
 // write reference benchmark point
-// #define BENCH_POINT_WRITE
+// use --binwrite option
 // print out more debug info, by default, only print out failures
 // #define BENCH_PRINT_DEBUG
 // print out comparisaon statistics

--- a/src/headers/dyn/thor_vertical_int.h
+++ b/src/headers/dyn/thor_vertical_int.h
@@ -89,8 +89,13 @@ __global__ void Vertical_Eq(double *Whs_d,
     extern __shared__ double mem_shared[];
 
 
-    double *cc = (double *)mem_shared;
-    double *dd = (double *)&mem_shared[blockDim.x * nvi];
+    // Use thomas algorithm to solve vertical equations. 
+    // This computes the aa, bb, cc, dd values in the loop.
+    // cc and dd are stored, and UPDATED by the "modify in place" thomas algorithm.
+    // To avoid storing aa and bb, they are recomputed on the fly. 
+    double *cc = (double *)mem_shared;                    // <- thomas alg vars
+    double *dd = (double *)&mem_shared[blockDim.x * nvi]; // <- thomas alg vars
+
 
     // double Cv = Cp - Rd;
     double C0;
@@ -98,7 +103,7 @@ __global__ void Vertical_Eq(double *Whs_d,
     double intt, intl, inttm, intlm;
     double dSpdz, dPdz;
     double rhohs;
-    double aa, bb;
+    double aa, bb; // <- thomas alg vars
     double t;
     double althl, alth, altht;
     double alt, altl;
@@ -111,6 +116,9 @@ __global__ void Vertical_Eq(double *Whs_d,
     double CRddl, CRddu, CRdd;
     double or2;
     double tor3;
+
+    // For thomas algorithm to be stable, |aa| + |cc| < |bb|, the matrix must be
+    // diagonaly dominant and symetric positive definite 
 
     if (id < num) {
         for (int lev = 1; lev < nv; lev++) {
@@ -254,6 +262,7 @@ __global__ void Vertical_Eq(double *Whs_d,
                 xim = althl;
                 xip = alth;
 
+                // compute coefficients aa, bb, cc of thomas algorithm original matrix
                 inttm = -(xi - xip) * dzm * dzh;
                 intlm = (xi - xim) * dzm * dzh;
 
@@ -269,6 +278,7 @@ __global__ void Vertical_Eq(double *Whs_d,
                     bb = (dzph + dzmh) * h + (intl - inttm) * (g + GCoR);
 
                 aa = -dzmh * hm + intlm * (gm + GCoR);
+                // end of coefficients computation
 
                 dSpdz = (Sp - Spl) * dzh;
                 dPdz  = (p - pl) * dzh;
@@ -341,23 +351,27 @@ __global__ void Vertical_Eq(double *Whs_d,
                 }
             }
 #endif // CHECK_THOR_VERTICAL_INT_THOMAS_DIAG_DOM
+            // Compute dd coefficient of thomas algorithm
             dd[threadIdx.x * nvi + lev] = -C0;
+            // "modify in place" computation of thomas algorithm
             if (lev == 1) {
                 cc[threadIdx.x * nvi + 1] = cc[threadIdx.x * nvi + 1] / bb;
                 dd[threadIdx.x * nvi + 1] = dd[threadIdx.x * nvi + 1] / bb;
             }
             else {
+                // as the previous iteration value is not stored, it's recomputed here
                 t = 1.0 / (bb - cc[threadIdx.x * nvi + lev - 1] * aa);
                 cc[threadIdx.x * nvi + lev] *= t;
                 dd[threadIdx.x * nvi + lev] =
                     (dd[threadIdx.x * nvi + lev] - dd[threadIdx.x * nvi + lev - 1] * aa) * t;
             }
         } //end of loop over levels
+	// end of thomass algorithm
         Whs_d[id * nvi + nv]     = 0.0;
         Whs_d[id * nvi]          = 0.0;
         Whs_d[id * nvi + nv - 1] = dd[threadIdx.x * nvi + nv - 1];
         // Whs_d[id * nvi + nv - 1] = 0.0;
-        // Updates vertical momentum
+        // Updates vertical momentum from output of thomas algorithm.
         for (int lev = nvi - 2; lev > 0; lev--)
             Whs_d[id * nvi + lev] = (-cc[threadIdx.x * nvi + lev] * Whs_d[id * nvi + lev + 1]
                                      + dd[threadIdx.x * nvi + lev]);

--- a/src/headers/vector_operations.h
+++ b/src/headers/vector_operations.h
@@ -224,7 +224,8 @@ inline __host__ __device__ double4 inv2x2(const double4 A) {
     {
       printf("Warning, NaN determinant for matrix inversion [[ %g, %g ], [ %g, %g ]], det: %g\n",
 	   A.x, A.y, A.z, A.w,  A.x*A.w - A.y*A.z );
-      exit(-1);
+      // This is not really allowed here...
+      // exit(-1);
     }
   return make_double4(det_inv*A.w,
 		      -det_inv*A.y,

--- a/src/physics/managers/empty/Makefile
+++ b/src/physics/managers/empty/Makefile
@@ -54,6 +54,10 @@ vpath %.cu $(SHARED_MODULES_DIR)
 vpath %.cpp $(SHARED_MODULES_DIR)
 
 
+ifndef VERBOSE
+.SILENT:
+endif
+
 #######################################################################
 # create directory
 $(BUILDDIR):
@@ -64,7 +68,7 @@ $(BUILDDIR):
 INCLUDE_DIRS = -I$(SHARED_MODULES_INCLUDE) -I$(THOR_INCLUDE) -I$(LOCAL_INCLUDE)
 
 $(BUILDDIR)/phy_modules.o: phy_modules.cu phy_modules.h phy_module_base.h | $(BUILDDIR)
-	@echo $(YELLOW)creating $@ $(END)
+	@echo -e '$(YELLOW)creating $@ $(END)'
 	# test if we build with compilation database (clang) or not (nvcc)	
 	if test $$CDB = "-MJ" ; then \
 		$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) $(INCLUDE_DIRS) $(CDB) $@.json -o $@ $<; \
@@ -74,18 +78,18 @@ $(BUILDDIR)/phy_modules.o: phy_modules.cu phy_modules.h phy_module_base.h | $(BU
 
 
 libphy_modules.a: $(BUILDDIR)/phy_modules.o | $(BUILDDIR)
-	@echo $(YELLOW)creating $@ $(END)
-	@echo $(GREEN)Linking Modules into static lib $(END)
+	@echo -e '$(YELLOW)creating $@ $(END)'
+	@echo -e '$(GREEN)Linking Modules into static lib $(END)'
 	ar rcs $@ $(BUILDDIR)/phy_modules.o 
 
 #######################################################################
 # Cleanup
 .phony: clean,ar
 clean:
-	@echo $(CYAN)clean up library $(END)
+	@echo '$(CYAN)clean up library $(END)'
 	-$(RM) libphy_modules.a
-	@echo $(CYAN)clean up modules objects $(END)
+	@echo -e '$(CYAN)clean up modules objects $(END)'
 	-$(RM) $(BUILDDIR)/phy_modules.o
 	-$(RM) $(BUILDDIR)/phy_modules.o.json
-	@echo $(CYAN)remove modules object dir $(END)
+	@echo -e '$(CYAN)remove modules object dir $(END)'
 	-$(RM) -d $(BUILDDIR)

--- a/src/physics/managers/empty/Makefile
+++ b/src/physics/managers/empty/Makefile
@@ -69,12 +69,7 @@ INCLUDE_DIRS = -I$(SHARED_MODULES_INCLUDE) -I$(THOR_INCLUDE) -I$(LOCAL_INCLUDE)
 
 $(BUILDDIR)/phy_modules.o: phy_modules.cu phy_modules.h phy_module_base.h | $(BUILDDIR)
 	@echo -e '$(YELLOW)creating $@ $(END)'
-	# test if we build with compilation database (clang) or not (nvcc)	
-	if test $$CDB = "-MJ" ; then \
-		$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) $(INCLUDE_DIRS) $(CDB) $@.json -o $@ $<; \
-	else \
-		$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) $(INCLUDE_DIRS) -o $@ $<; \
-	fi
+	$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) $(INCLUDE_DIRS) $(CDB) -o $@ $<; \
 
 
 libphy_modules.a: $(BUILDDIR)/phy_modules.o | $(BUILDDIR)

--- a/src/physics/managers/empty/Makefile
+++ b/src/physics/managers/empty/Makefile
@@ -86,7 +86,7 @@ libphy_modules.a: $(BUILDDIR)/phy_modules.o | $(BUILDDIR)
 # Cleanup
 .phony: clean,ar
 clean:
-	@echo '$(CYAN)clean up library $(END)'
+	@echo -e '$(CYAN)clean up library $(END)'
 	-$(RM) libphy_modules.a
 	@echo -e '$(CYAN)clean up modules objects $(END)'
 	-$(RM) $(BUILDDIR)/phy_modules.o

--- a/src/physics/managers/multi/Makefile
+++ b/src/physics/managers/multi/Makefile
@@ -75,45 +75,31 @@ $(BUILDDIR):
 $(BUILDDIR)/${OUTPUTDIR}: $(BUILDDIR)
 		mkdir -p $(BUILDDIR)/$(OUTPUTDIR)
 
+
 #######################################################################
 # build objects
 
 INCLUDE_DIRS = -I$(SHARED_MODULES_INCLUDE) -I$(THOR_INCLUDE) -I$(LOCAL_INCLUDE)
 
-$(BUILDDIR)/${OUTPUTDIR}/chemistry.o: chemistry.cu chemistry.h phy_modules.h phy_module_base.h thor_chemistry.h | $(BUILDDIR)
-	@echo -e '$(YELLOW)creating $@ $(END)'
-	if test $$CDB = "-MJ" ; then \
-		$(CC) $(CC_comp_flag) $(arch) $(cuda_flags) $(h5include) $(h5libdir) $(INCLUDE_DIRS) $(CDB) $@.json -o $@ $<; \
-	else \
-		$(CC) $(CC_comp_flag) $(arch) $(cuda_flags) $(h5include) $(h5libdir) $(INCLUDE_DIRS) -o $@ $<; \
-	fi
+$(BUILDDIR)/${OUTPUTDIR}/chemistry.o: chemistry.cu chemistry.h phy_modules.h phy_module_base.h thor_chemistry.h | $(BUILDDIR)/${OUTPUTDIR} $(BUILDDIR) 
+	@echo -e '$(YELLOW)creating object file for $@ $(END)'
+	$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) -I$(includedir) $(INCLUDE_DIRS) $(CDB)  -o $@ $<
 
-$(BUILDDIR)/${OUTPUTDIR}/radiative_transfer.o: radiative_transfer.cu radiative_transfer.h profx_RT.h phy_modules.h phy_module_base.h | $(BUILDDIR)/${OUTPUTDIR}
-	@echo -e '$(YELLOW)creating $@ $(END)'
-	if test $$CDB = "-MJ" ; then \
-		$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) $(h5libdir) $(INCLUDE_DIRS) $(CDB) $@.json -o $@ $<; \
-	else \
-		$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) $(h5libdir) $(INCLUDE_DIRS) -o $@ $<; \
-	fi
-
-$(BUILDDIR)/${OUTPUTDIR}/boundary_layer.o: boundary_layer.cu boundary_layer.h phy_modules.h phy_module_base.h | $(BUILDDIR)/${OUTPUTDIR}
-	@echo -e '$(YELLOW)creating $@ $(END)'
-	if test $$CDB = "-MJ" ; then \
-		$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) $(h5libdir) $(INCLUDE_DIRS) $(CDB) $@.json -o $@ $<; \
-	else \
-		$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) $(h5libdir) $(INCLUDE_DIRS) -o $@ $<; \
-	fi
-
-$(BUILDDIR)/${OUTPUTDIR}/phy_modules.o: phy_modules.cu phy_modules.h phy_module_base.h | $(BUILDDIR)/${OUTPUTDIR}
-	@echo -e '$(YELLOW)creating $@ $(END)'
-	if test $$CDB = "-MJ" ; then \
-		$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) $(INCLUDE_DIRS) $(CDB) $@.json -o $@ $<; \
-	else \
-		$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) $(INCLUDE_DIRS) -o $@ $<; \
-	fi
+$(BUILDDIR)/${OUTPUTDIR}/radiative_transfer.o: radiative_transfer.cu radiative_transfer.h profx_RT.h phy_modules.h phy_module_base.h | $(BUILDDIR)/${OUTPUTDIR} $(BUILDDIR) 
+	@echo -e '$(YELLOW)creating object file for $@ $(END)'
+	$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) -I$(includedir)  $(INCLUDE_DIRS) $(CDB)  -o $@ $<
 
 
-libphy_modules.a: $(BUILDDIR)/${OUTPUTDIR}/chemistry.o $(BUILDDIR)/${OUTPUTDIR}/radiative_transfer.o $(BUILDDIR)/${OUTPUTDIR}/boundary_layer.o $(BUILDDIR)/${OUTPUTDIR}/phy_modules.o | $(BUILDDIR)
+$(BUILDDIR)/${OUTPUTDIR}/boundary_layer.o: boundary_layer.cu boundary_layer.h phy_modules.h phy_module_base.h | $(BUILDDIR)/${OUTPUTDIR} $(BUILDDIR) 
+	@echo -e '$(YELLOW)creating object file for $@ $(END)'
+	$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) -I$(includedir) $(INCLUDE_DIRS) $(CDB)  -o $@ $<
+
+$(BUILDDIR)/${OUTPUTDIR}/phy_modules.o: phy_modules.cu phy_modules.h phy_module_base.h | $(BUILDDIR)/${OUTPUTDIR} $(BUILDDIR) 
+	@echo -e '$(YELLOW)creating object file for $@ $(END)'
+	$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) -I$(includedir) $(INCLUDE_DIRS) $(CDB)  -o $@ $<
+
+
+libphy_modules.a: $(BUILDDIR)/${OUTPUTDIR}/chemistry.o $(BUILDDIR)/${OUTPUTDIR}/radiative_transfer.o $(BUILDDIR)/${OUTPUTDIR}/boundary_layer.o $(BUILDDIR)/${OUTPUTDIR}/phy_modules.o | $(BUILDDIR)/${OUTPUTDIR} $(BUILDDIR)
 	@echo -e '$(YELLOW)creating $@ $(END)'
 	@echo -e '$(GREEN)Linking Modules into static lib $(END)'
 	ar rcs $@ $(BUILDDIR)/${OUTPUTDIR}/phy_modules.o $(BUILDDIR)/${OUTPUTDIR}/radiative_transfer.o $(BUILDDIR)/${OUTPUTDIR}/boundary_layer.o $(BUILDDIR)/${OUTPUTDIR}/chemistry.o

--- a/src/physics/managers/multi/Makefile
+++ b/src/physics/managers/multi/Makefile
@@ -42,6 +42,11 @@ SHARED_MODULES_DIR = $(THOR_ROOT)src/physics/modules/src/
 BUILDDIR = obj
 OUTPUTDIR = $(MODE)
 
+
+ifndef VERBOSE
+.SILENT:
+endif
+
 ######################################################################
 $(info Sub Makefile variables)
 $(info THOR root from submakefile: $(THOR_ROOT))
@@ -76,7 +81,7 @@ $(BUILDDIR)/${OUTPUTDIR}: $(BUILDDIR)
 INCLUDE_DIRS = -I$(SHARED_MODULES_INCLUDE) -I$(THOR_INCLUDE) -I$(LOCAL_INCLUDE)
 
 $(BUILDDIR)/${OUTPUTDIR}/chemistry.o: chemistry.cu chemistry.h phy_modules.h phy_module_base.h thor_chemistry.h | $(BUILDDIR)
-	@echo $(YELLOW)creating $@ $(END)
+	@echo -e '$(YELLOW)creating $@ $(END)'
 	if test $$CDB = "-MJ" ; then \
 		$(CC) $(CC_comp_flag) $(arch) $(cuda_flags) $(h5include) $(h5libdir) $(INCLUDE_DIRS) $(CDB) $@.json -o $@ $<; \
 	else \
@@ -84,7 +89,7 @@ $(BUILDDIR)/${OUTPUTDIR}/chemistry.o: chemistry.cu chemistry.h phy_modules.h phy
 	fi
 
 $(BUILDDIR)/${OUTPUTDIR}/radiative_transfer.o: radiative_transfer.cu radiative_transfer.h profx_RT.h phy_modules.h phy_module_base.h | $(BUILDDIR)/${OUTPUTDIR}
-	@echo $(YELLOW)creating $@ $(END)
+	@echo -e '$(YELLOW)creating $@ $(END)'
 	if test $$CDB = "-MJ" ; then \
 		$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) $(h5libdir) $(INCLUDE_DIRS) $(CDB) $@.json -o $@ $<; \
 	else \
@@ -92,7 +97,7 @@ $(BUILDDIR)/${OUTPUTDIR}/radiative_transfer.o: radiative_transfer.cu radiative_t
 	fi
 
 $(BUILDDIR)/${OUTPUTDIR}/boundary_layer.o: boundary_layer.cu boundary_layer.h phy_modules.h phy_module_base.h | $(BUILDDIR)/${OUTPUTDIR}
-	@echo $(YELLOW)creating $@ $(END)
+	@echo -e '$(YELLOW)creating $@ $(END)'
 	if test $$CDB = "-MJ" ; then \
 		$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) $(h5libdir) $(INCLUDE_DIRS) $(CDB) $@.json -o $@ $<; \
 	else \
@@ -100,7 +105,7 @@ $(BUILDDIR)/${OUTPUTDIR}/boundary_layer.o: boundary_layer.cu boundary_layer.h ph
 	fi
 
 $(BUILDDIR)/${OUTPUTDIR}/phy_modules.o: phy_modules.cu phy_modules.h phy_module_base.h | $(BUILDDIR)/${OUTPUTDIR}
-	@echo $(YELLOW)creating $@ $(END)
+	@echo -e '$(YELLOW)creating $@ $(END)'
 	if test $$CDB = "-MJ" ; then \
 		$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) $(INCLUDE_DIRS) $(CDB) $@.json -o $@ $<; \
 	else \
@@ -109,17 +114,17 @@ $(BUILDDIR)/${OUTPUTDIR}/phy_modules.o: phy_modules.cu phy_modules.h phy_module_
 
 
 libphy_modules.a: $(BUILDDIR)/${OUTPUTDIR}/chemistry.o $(BUILDDIR)/${OUTPUTDIR}/radiative_transfer.o $(BUILDDIR)/${OUTPUTDIR}/boundary_layer.o $(BUILDDIR)/${OUTPUTDIR}/phy_modules.o | $(BUILDDIR)
-	@echo $(YELLOW)creating $@ $(END)
-	@echo $(GREEN)Linking Modules into static lib $(END)
+	@echo -e '$(YELLOW)creating $@ $(END)'
+	@echo -e '$(GREEN)Linking Modules into static lib $(END)'
 	ar rcs $@ $(BUILDDIR)/${OUTPUTDIR}/phy_modules.o $(BUILDDIR)/${OUTPUTDIR}/radiative_transfer.o $(BUILDDIR)/${OUTPUTDIR}/boundary_layer.o $(BUILDDIR)/${OUTPUTDIR}/chemistry.o
 
 #######################################################################
 # Cleanup
 .phony: clean,ar
 clean:
-	@echo $(CYAN)clean up library $(END)
+	@echo -e '$(CYAN)clean up library $(END)'
 	-$(RM) libphy_modules.a
-	@echo $(CYAN)clean up modules objects $(END)
+	@echo -e '$(CYAN)clean up modules objects $(END)'
 	-$(RM) $(BUILDDIR)/debug/*.o
 	-$(RM) $(BUILDDIR)/debug/*.o.json
 	-$(RM) $(BUILDDIR)/release/*.o
@@ -129,5 +134,5 @@ clean:
 	-$(RM) -d $(BUILDDIR)/debug/
 	-$(RM) -d $(BUILDDIR)/release/
 	-$(RM) -d $(BUILDDIR)/prof/
-	@echo $(CYAN)remove modules object dir $(END)
+	@echo -e '$(CYAN)remove modules object dir $(END)'
 	-$(RM) -d $(BUILDDIR)

--- a/src/physics/modules/inc/radiative_transfer.h
+++ b/src/physics/modules/inc/radiative_transfer.h
@@ -74,6 +74,9 @@ public:
         Qheat_scaling = scaling;
     };
 
+    // DEBUG: hack, for debug printout in Alf.
+    double * get_debug_qheat_device_ptr() { return qheat_d; };
+
 private:
   // Scaling of Qheat, for slow ramp up or ramp down.
   double Qheat_scaling = 1.0;

--- a/src/utils/binary_test.cpp
+++ b/src/utils/binary_test.cpp
@@ -451,7 +451,14 @@ map<string, output_def> build_definitions(ESP& esp, Icogrid& grid) {
               {"halo",          { grid.halo, grid.nh, "halo", "halo", false}},
               {"maps",          { grid.maps, (grid.nl_region+2)*(grid.nl_region+2)*grid.nr, "maps", "m", false}},
             */
-
+        {"func_r_d",
+         {esp.func_r_d,
+          3 * grid.point_num,
+          "func_r_d",
+          "fd",
+          true,
+          std::bind(
+              &ESP::index_to_location_3xn, &esp, std::placeholders::_1, std::placeholders::_2)}},
         {"func_r",
          {grid.func_r,
           3 * grid.point_num,

--- a/src/utils/binary_test.cpp
+++ b/src/utils/binary_test.cpp
@@ -629,14 +629,11 @@ void binary_test::check_data(const string&         iteration,
 
 
 // Specific debugging functions
-#    ifdef BENCH_POINT_WRITE
-    output_reference(iteration, ref_name, data_output);
-#    endif // BENCH_POINT_WRITE
+    if (use_write)
+      output_reference(iteration, ref_name, data_output);
 
-#    ifdef BENCH_POINT_COMPARE
-    compare_to_reference(iteration, ref_name, data_output);
-
-#    endif // BENCH_POINT_COMPARE
+    if (use_compare)
+      compare_to_reference(iteration, ref_name, data_output);
 
 #    ifdef BENCH_NAN_CHECK
     if (nan_check_d == nullptr) {

--- a/src/utils/cmdargs.cpp
+++ b/src/utils/cmdargs.cpp
@@ -61,12 +61,12 @@ using std::endl;
 // Number of arguments following this key is 0
 template<> int arg<bool>::get_nargs() {
     return 0;
-};
+}
 
 // Flag it as set, it will use its predefined value
 template<> void arg<bool>::set_default() {
     has_value = true;
-};
+}
 
 
 cmdargs::cmdargs(const string& app_name_, const string& app_desc_) :

--- a/src/utils/log_writer.cpp
+++ b/src/utils/log_writer.cpp
@@ -202,7 +202,7 @@ int log_writer::prepare_globdiag_file(bool append) {
 
 
     return 0;
-};
+}
 
 
 void log_writer::output_globdiag(int    current_step,
@@ -266,7 +266,7 @@ int log_writer::prepare_diagnostics_file(bool append) {
 
 
     return 0;
-};
+}
 
 
 void log_writer::output_diagnostics(int         current_step,


### PR DESCRIPTION
* makefile color fix for ubelix
* git branch/commit/dirty flag read by makefile and added to program output (autogenerates "git-rev.h" file defining variables for output in printf)
* git branch/commit/dirty flag read by cmake and added to program output (autogenerates "git-rev.h" file defining variables for output in printf)
* add latest alfrodull submodule, that compiles with makefile and cmake
* mjolnyr options to plot only summary of last output
* some benchpoints and cudaDeviceSynchronise for further debug. If esp is run in a loop, seems to inconsistently have binary incompatibilities after 30 to 60 steps after Correct_Horizontal, need to check more, not always reproducible. 
* converted binary compatibility to be enabled simply with BENCHMARKING at compile time, and operation activated with option at runtime: write ("--binwrite") and compare ("--bincompare") 
* some protection in cudadevicememory to avoid acting on undefined array.
* some comments on thor_fastmode and vertical_int  to explicit variable usage a bit and sensitive points in algorithm that bring to crash on low pressure.
* get rid of some compile time warnings on unnecessary ";"