### PR TITLE
Alfclass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,7 @@ results*/
 profiling/*
 # compile command database
 compile_commands.json
+# version information generated at compile time
+include/git-rev.h
 
 

--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,26 @@ release: symlink
 prof: symlink
 cdb:
 
+#######################################################################
+# test for alfrodull
+ifeq ($(wildcard Alfrodull),)
+	ALFRODULL_FLAGS =
+	ALFRODULL_LINK_FLAGS =
+else 
+
+	ALFRODULL_FLAGS = -DHAS_ALFRODULL -IAlfrodull/thor_module/inc/
+    ALFRODULL_LINK_FLAGS =  -LAlfrodull -lalfrodull
+	ALFRODULL_TARGET = Alfrodull/libalfrodull.a
+export
+# always call submakefile for alf
+.PHONY: Alfrodull/libalfrodull.a
+Alfrodull/libalfrodull.a:
+	@echo -e '$(MAGENTA)Creating Alfrodull from subdir Alfrodull$(END)'
+	$(MAKE) -f Makefile -C Alfrodull
+
+endif 
+
+
 
 
 #######################################################################
@@ -268,30 +288,30 @@ $(OBJDIR)/${OUTPUTDIR}/$(DEPDIR): $(OBJDIR)/${OUTPUTDIR} $(OBJDIR)
 # CUDA files
 $(OBJDIR)/${OUTPUTDIR}/esp.o: esp.cu $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/esp.d $(GITREV_FILE) | $(OBJDIR)/${OUTPUTDIR}/$(DEPDIR) $(OBJDIR)/$(OUTPUTDIR) $(OBJDIR)
 	@echo -e '$(BLUE)creating dependencies for $@ $(END)'
-	$(CC) $(cuda_dependencies_flags) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) -I$(includedir) -I$(OBJDIR)/$(OUTPUTDIR) $(CDB)  -o $@ $<
+	$(CC) $(cuda_dependencies_flags) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) -I$(includedir)  -I$(OBJDIR)/$(OUTPUTDIR) $(CDB) $(ALFRODULL_FLAGS) -o $@ $<
 	@echo -e '$(YELLOW)creating object file for $@ $(END)'
-	$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) -I$(includedir) -I$(OBJDIR)/$(OUTPUTDIR) $(CDB)  -o $@ $<
+	$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) -I$(includedir) -I$(OBJDIR)/$(OUTPUTDIR) $(CDB) $(ALFRODULL_FLAGS) -o $@ $<
 
 
 $(OBJDIR)/${OUTPUTDIR}/%.o: %.cu $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/%.d  | $(OBJDIR)/${OUTPUTDIR}/$(DEPDIR) $(OBJDIR)/$(OUTPUTDIR) $(OBJDIR) 
 	@echo -e '$(BLUE)creating dependencies for $@ $(END)'
-	$(CC) $(cuda_dependencies_flags) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) -I$(includedir) $(CDB) -o $@ $<
+	$(CC) $(cuda_dependencies_flags) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) -I$(includedir) $(CDB) $(ALFRODULL_FLAGS) -o $@ $<
 	@echo -e '$(YELLOW)creating object file for $@ $(END)'
-	$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) -I$(includedir) $(CDB) -o $@ $<
+	$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) -I$(includedir) $(CDB) $(ALFRODULL_FLAGS) -o $@ $<
 
 # C++ files
 $(OBJDIR)/${OUTPUTDIR}/%.o: %.cpp $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/%.d  | $(OBJDIR)/${OUTPUTDIR}/$(DEPDIR) $(OBJDIR)/$(OUTPUTDIR) $(OBJDIR)
 	@echo -e '$(YELLOW)creating dependencies and object file for $@  $(END)'
-	$(CC) $(dependencies_flags) $(CC_comp_flag) $(arch) $(cpp_flags) $(h5include) -I$(includedir) $(CDB) -o $@ $<
+	$(CC) $(dependencies_flags) $(CC_comp_flag) $(arch) $(cpp_flags) $(h5include) -I$(includedir) $(CDB) $(ALFRODULL_FLAGS) -o $@ $<
 
 # Target for dependencies, so that they are always defined
 $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/%.d: ;
 
 # link *.o objects
 .PHONY: 
-$(BINDIR)/${OUTPUTDIR}/esp: $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj)) $(MODULES_SRC)/libphy_modules.a  | $(BINDIR) $(RESDIR) $(BINDIR)/$(OUTPUTDIR)  $(OBJDIR)
+$(BINDIR)/${OUTPUTDIR}/esp: $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj)) $(MODULES_SRC)/libphy_modules.a $(ALFRODULL_TARGET) | $(BINDIR) $(RESDIR) $(BINDIR)/$(OUTPUTDIR)  $(OBJDIR)
 	@echo -e '$(YELLOW)creating $@ $(END)'
-	$(CC) -o $(BINDIR)/$(OUTPUTDIR)/esp $(arch) $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj)) -L$(MODULES_SRC) -lphy_modules $(h5libdir) $(h5libs) $(link_flags)
+	$(CC) -o $(BINDIR)/$(OUTPUTDIR)/esp $(arch) $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj)) -L$(MODULES_SRC) -lphy_modules $(h5libdir) $(h5libs) $(link_flags) $(ALFRODULL_LINK_FLAGS)
 	if [ "$(HAS_CDB)" = "-MJ" ] ; then \
 		rm -f compile_commands.json; \
 		sed -e '1s/^/[\n/' -e '$$s/,$$/\n]/' $(OBJDIR)/$(OUTPUTDIR)/*.o.json $(MODULES_SRC)/obj/*.o.json > compile_commands.json; \

--- a/Makefile
+++ b/Makefile
@@ -220,9 +220,8 @@ ifeq ($(wildcard Alfrodull),)
 	ALFRODULL_LINK_FLAGS =
 else 
 
-	ALFRODULL_FLAGS = -DHAS_ALFRODULL -IAlfrodull/thor_module/inc/
-    ALFRODULL_LINK_FLAGS =  -LAlfrodull -lalfrodull
-	ALFRODULL_TARGET = Alfrodull/libalfrodull.a
+ALFRODULL_LINK_FLAGS =  -LAlfrodull -lalfrodull
+ALFRODULL_TARGET = Alfrodull/libalfrodull.a
 export
 # always call submakefile for alf
 .PHONY: Alfrodull/libalfrodull.a
@@ -233,7 +232,7 @@ Alfrodull/libalfrodull.a:
 endif 
 
 
-
+$(info alf flags: $(ALFRODULL_FLAGS))
 
 #######################################################################
 # main binary

--- a/ifile/alf_wasp_alf.thr
+++ b/ifile/alf_wasp_alf.thr
@@ -281,6 +281,15 @@ sync_rot = true
 #longp = 0
 #########################################################
 
+#########################################################
+# spin up and spin down start and stop. Set to negative value to ignore and run at full power
+# spins up/down with a multiplication factor following a sine from 0 to 1 from
+# start to stop of spin up time
+dgrt_spinup_start = 0
+dgrt_spinup_stop = 9
+dgrt_spindown_start = 10
+dgrt_spindown_stop = 20
+
 
 #-- Alfrodull options --------------------------------------------------------#
 # also uses variables from general config and radiative transfer:
@@ -335,16 +344,21 @@ Alf_opacities_file = ./Alfrodull/input/opac_sample_r5.h5
 # G_+/- limits to protect against exploding value
 # Alf_G_pm_max_limiter =
 # Alf_G_pm_denom_limit
-# Alf_G_pm_mu_star_increment
+# wiggle increment in degrees to add to zenith angle if G_+/- explodes
+Alf_G_pm_mu_star_increment = 1.0
 
 # compute radiative transfer every n step
 Alf_compute_every_nstep = 1
 
-# number of double gray radiative transfer spinup steps before shifting progressivelly to two stream
-Alf_dgrt_spinup_steps = 0
+#########################################################
+# spin up and spin down start and stop. Set to negative value to ignore and run at full power
+# spins up/down with a multiplication factor following a sine from 0 to 1 from
+# start to stop of spin up time
+Alf_spinup_start = 10
+Alf_spinup_stop = 20
+Alf_spindown_start = -1
+Alf_spindown_stop = -1
 
-# number of steps to spinup from 0 to full Qheat
-Alf_spinup_steps = 0
 
 #-- Boundary layer options (core_benchmark = NoBenchmark) --------------------#
 boundary_layer = false

--- a/ifile/wasp43b_ex.thr
+++ b/ifile/wasp43b_ex.thr
@@ -280,8 +280,15 @@ sync_rot = true
 # (stupid Earth convention applies)
 #longp = 0
 #########################################################
+# spin up and spin down start and stop. Set to negative value to ignore and run at full power
+# spins up/down with a multiplication factor following a sine from 0 to 1 from
+# start to stop of spin up time
+#dgrt_spinup_start = -1
+#dgrt_spinup_stop = -1
+#dgrt_spindown_start = -1
+#dgrt_spindown_stop = -1
 
-
+#########################################################
 #-- Boundary layer options (core_benchmark = NoBenchmark) --------------------#
 boundary_layer = false
 

--- a/mjolnir/hamarr.py
+++ b/mjolnir/hamarr.py
@@ -55,10 +55,10 @@ class input_new:
             setattr(self,key,openh5[key][...])
 
         #special cases (things we test on a lot, etc)
-        self.RT = "radiative_transfer" in openh5
-        self.TSRT = "two_streams_radiative_transfer" in openh5
-        if "chemistry" in openh5:
-            self.chemistry = openh5['chemistry'][0]
+        self.RT = "radiative_transfer" in openh5 and openh5["radiative_transfer"][0] == 1.0
+        self.TSRT = "two_streams_radiative_transfer" in openh5 and openh5["two_streams_radiative_transfer"][0] == 1.0
+        self.chemistry = "chemistry" in openh5 and openh5["chemistry" ][0] == 1
+
         if not hasattr(self,'surface'):
             self.surface = False
         #some bw compatibility things
@@ -163,7 +163,10 @@ class output_new:
             outputs['F_dir_tot'] = 'f_dir_tot'
             outputs['F_net'] = 'f_net'
             outputs['Alf_Qheat'] = 'TSqheat'
-            outputs['col_mu_star'] = 'mustar'
+            # for rename transition of col_mu_star, can be removed later
+            #outputs['zenith_angles'] = 'mustar'
+            outputs['cos_zenith_angles'] = 'mustar'
+            #outputs['col_mu_star'] = 'mustar'
             outputs['F_up_TOA_spectrum'] = 'spectrum'
             outputs['lambda_wave'] = 'wavelength'
 

--- a/mjolnir/mjolnyr.ipynb
+++ b/mjolnir/mjolnyr.ipynb
@@ -1145,22 +1145,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/src/ESP/thor_driver.cu
+++ b/src/ESP/thor_driver.cu
@@ -423,7 +423,7 @@ __host__ void ESP::Thor(const SimulationSetup& sim) {
                             ("diffmh_d", "diffw_d", "diffrh_d", "diffpr_d", "diff_d"))
 
 
-            Correct_Horizontal<<<NBALL, NTH>>>(diffmh_d, diffmv_d, func_r_d, point_num);
+            Correct_Horizontal<<<NBALL1, NTH>>>(diffmh_d, diffmv_d, func_r_d, point_num);
 
             cudaDeviceSynchronize();
 

--- a/src/physics/managers/multi/Makefile
+++ b/src/physics/managers/multi/Makefile
@@ -21,6 +21,7 @@ $(info CC compile flag: $(CC_comp_flag))
 $(info arch: $(arch))
 $(info MODE: $(MODE))
 
+
 ######################################################################
 # Directories
 THOR_ROOT = ../../../../
@@ -30,6 +31,16 @@ LOCAL_INCLUDE = inc
 
 # shared modules
 SHARED_MODULES_INCLUDE = $(THOR_ROOT)src/physics/modules/inc/
+
+ifeq ($(wildcard $(THOR_ROOT)Alfrodull),)
+	ALFRODULL_FLAGS =
+	ALFCLASS = 
+else 
+	ALFRODULL_FLAGS = -DHAS_ALFRODULL=1 -I$(THOR_ROOT)Alfrodull/thor_module/inc/ -I$(THOR_ROOT)Alfrodull/src/inc/
+	ALFCLASS = $(THOR_ROOT)Alfrodull/thor_module/inc/two_stream_radiative_transfer.h
+endif 
+
+
 
 # thor root include if we want to use code from there
 THOR_INCLUDE = $(THOR_ROOT)src/headers
@@ -94,15 +105,17 @@ $(BUILDDIR)/${OUTPUTDIR}/boundary_layer.o: boundary_layer.cu boundary_layer.h ph
 	@echo -e '$(YELLOW)creating object file for $@ $(END)'
 	$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) -I$(includedir) $(INCLUDE_DIRS) $(CDB)  -o $@ $<
 
-$(BUILDDIR)/${OUTPUTDIR}/phy_modules.o: phy_modules.cu phy_modules.h phy_module_base.h | $(BUILDDIR)/${OUTPUTDIR} $(BUILDDIR) 
+$(BUILDDIR)/${OUTPUTDIR}/phy_modules.o: phy_modules.cu phy_modules.h phy_module_base.h $(ALFCLASS) | $(BUILDDIR)/${OUTPUTDIR} $(BUILDDIR) 
 	@echo -e '$(YELLOW)creating object file for $@ $(END)'
-	$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) -I$(includedir) $(INCLUDE_DIRS) $(CDB)  -o $@ $<
+	$(CC) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) -I$(includedir) $(INCLUDE_DIRS) $(CDB) $(ALFRODULL_FLAGS) -o $@ $<
 
 
 libphy_modules.a: $(BUILDDIR)/${OUTPUTDIR}/chemistry.o $(BUILDDIR)/${OUTPUTDIR}/radiative_transfer.o $(BUILDDIR)/${OUTPUTDIR}/boundary_layer.o $(BUILDDIR)/${OUTPUTDIR}/phy_modules.o | $(BUILDDIR)/${OUTPUTDIR} $(BUILDDIR)
 	@echo -e '$(YELLOW)creating $@ $(END)'
 	@echo -e '$(GREEN)Linking Modules into static lib $(END)'
 	ar rcs $@ $(BUILDDIR)/${OUTPUTDIR}/phy_modules.o $(BUILDDIR)/${OUTPUTDIR}/radiative_transfer.o $(BUILDDIR)/${OUTPUTDIR}/boundary_layer.o $(BUILDDIR)/${OUTPUTDIR}/chemistry.o
+
+$(ALFCLASS): ;
 
 #######################################################################
 # Cleanup

--- a/src/physics/modules/inc/radiative_transfer.h
+++ b/src/physics/modules/inc/radiative_transfer.h
@@ -102,6 +102,11 @@ private:
     double Csurf_config    = 1e7;   // heat capacity of surface (J K^-1 m^-2)
     bool   rt1Dmode_config = false; // 1D mode=all columns are irradiated identically
 
+    int spinup_start_step = -1;
+    int spinup_stop_step  = -1;
+
+    int spindown_start_step = -1;
+    int spindown_stop_step  = -1;
     // Rad trans
     double Tstar            = 4520;  // Star effective temperature [K]
     double planet_star_dist = 0.015; // Planet-star distance [au]

--- a/src/physics/modules/src/radiative_transfer.cu
+++ b/src/physics/modules/src/radiative_transfer.cu
@@ -220,26 +220,27 @@ bool radiative_transfer::phy_loop(ESP &                  esp,
     bool run      = true;
     Qheat_scaling = 1.0;
 
+
     if (spinup_start_step > -1 && spinup_stop_step > -1) {
         if (nstep < spinup_start_step) // before spinup
         {
             run           = false;
             Qheat_scaling = 0.0;
         }
-        else if (nstep >= spinup_start_step && nstep < spinup_stop_step) // during spinup
+        else if ((nstep >= spinup_start_step) && (nstep <= spinup_stop_step)) // during spinup
         {
             double x = (double)(nstep - spinup_start_step)
-                       / (double)(spinup_stop_step - spinup_start_step + 1);
+                       / (double)(spinup_stop_step - spinup_start_step);
             Qheat_scaling = (1 + sin(M_PI * x - M_PI / 2.0)) / 2.0;
             run           = true;
         }
     }
 
     if (spindown_start_step > -1 && spindown_stop_step > -1) {
-        if (nstep >= spindown_start_step && nstep < spindown_stop_step) {
-            double x = (double)(spindown_stop_step - nstep)
+        if ((nstep >= spindown_start_step) && (nstep <= spindown_stop_step)) {
+            double x = (double)(nstep - spindown_start_step)
                        / (double)(spindown_stop_step - spindown_start_step);
-            Qheat_scaling = (1 + sin(M_PI * x - M_PI / 2.0)) / 2.0;
+            Qheat_scaling = 1.0 - (1 + sin(M_PI * x - M_PI / 2.0)) / 2.0;
             run           = true;
         }
         else if (nstep >= spindown_stop_step) {

--- a/src/physics/modules/src/radiative_transfer.cu
+++ b/src/physics/modules/src/radiative_transfer.cu
@@ -76,6 +76,12 @@ void radiative_transfer::print_config() {
     log::printf("    Surface                     = %s.\n", surface_config ? "true" : "false");
     log::printf("    Surface Heat Capacity       = %f J/K/m^2.\n", Csurf_config);
     log::printf("    1D mode                     = %s.\n", rt1Dmode_config ? "true" : "false");
+
+    // spinup-spindown parameters
+    log::printf("    Spin up start step          = %d.\n", spinup_start_step);
+    log::printf("    Spin up stop step           = %d.\n", spinup_stop_step);
+    log::printf("    Spin down start step        = %d.\n", spindown_start_step);
+    log::printf("    Spin down stop step         = %d.\n", spindown_stop_step);
 }
 
 bool radiative_transfer::initialise_memory(const ESP &              esp,
@@ -152,6 +158,18 @@ bool radiative_transfer::initial_conditions(const ESP &            esp,
                                             const SimulationSetup &sim,
                                             storage *              s) {
 
+    if (spinup_start_step > -1 || spinup_stop_step > -1) {
+        if (spinup_stop_step < spinup_start_step)
+            printf("DGRT: inconsistent spinup_start (%d) and spinup_stop (%d) values\n",
+                   spinup_start_step,
+                   spinup_stop_step);
+    }
+    if (spindown_start_step > -1 || spindown_stop_step > -1) {
+        if (spindown_stop_step < spindown_start_step)
+            printf("DGRT: inconsistent spindown_start (%d) and spindown_stop (%d) values\n",
+                   spindown_start_step,
+                   spindown_stop_step);
+    }
     RTSetup(Tstar_config,
             planet_star_dist_config,
             radius_star_config,
@@ -199,69 +217,102 @@ bool radiative_transfer::phy_loop(ESP &                  esp,
                                   const SimulationSetup &sim,
                                   int                    nstep, // Step number
                                   double                 time_step) {           // Time-step [s]
-    //
-    //  Number of threads per block.
-    const int NTH = 256;
+    bool run      = true;
+    Qheat_scaling = 1.0;
 
-    //  Specify the block sizes.
-    dim3 NB((esp.point_num / NTH) + 1, esp.nv, 1);
-    dim3 NBRT((esp.point_num / NTH) + 1, 1, 1);
+    if (spinup_start_step > -1 && spinup_stop_step > -1) {
+        if (nstep < spinup_start_step) // before spinup
+        {
+            run           = false;
+            Qheat_scaling = 0.0;
+        }
+        else if (nstep >= spinup_start_step && nstep < spinup_stop_step) // during spinup
+        {
+            double x = (double)(nstep - spinup_start_step)
+                       / (double)(spinup_stop_step - spinup_start_step + 1);
+            Qheat_scaling = (1 + sin(M_PI * x - M_PI / 2.0)) / 2.0;
+            run           = true;
+        }
+    }
 
-    rtm_dual_band<<<NBRT, NTH>>>(esp.pressure_d,
-                                 esp.Rho_d,
-                                 esp.temperature_d,
-                                 flw_up_d,
-                                 flw_dn_d,
-                                 fsw_up_d,
-                                 fsw_dn_d,
-                                 tau_d,
-                                 sim.Gravit,
-                                 esp.Cp_d,
-                                 esp.lonlat_d,
-                                 esp.Altitude_d,
-                                 esp.Altitudeh_d,
-                                 phtemp,
-                                 dtemp,
-                                 ttemp,
-                                 thtemp,
-                                 time_step,
-                                 Tstar,
-                                 planet_star_dist,
-                                 radius_star,
-                                 diff_ang,
-                                 esp.Tint,
-                                 albedo,
-                                 tausw,
-                                 taulw,
-                                 latf_lw,
-                                 taulw_pole,
-                                 n_sw,
-                                 n_lw,
-                                 esp.f_lw,
-                                 incflx,
-                                 sim.P_Ref,
-                                 esp.point_num,
-                                 esp.nv,
-                                 esp.nvi,
-                                 sim.A,
-                                 esp.insolation.get_r_orb(),
-                                 esp.insolation.get_device_cos_zenith_angles(),
-                                 insol_d,
-                                 surface,
-                                 Csurf,
-                                 Tsurface_d,
-                                 surf_flux_d,
-                                 esp.profx_Qheat_d,
-                                 qheat_d,
-                                 esp.Rd_d,
-                                 Qheat_scaling,
-                                 sim.gcm_off,
-                                 rt1Dmode);
+    if (spindown_start_step > -1 && spindown_stop_step > -1) {
+        if (nstep >= spindown_start_step && nstep < spindown_stop_step) {
+            double x = (double)(spindown_stop_step - nstep)
+                       / (double)(spindown_stop_step - spindown_start_step);
+            Qheat_scaling = (1 + sin(M_PI * x - M_PI / 2.0)) / 2.0;
+            run           = true;
+        }
+        else if (nstep >= spindown_stop_step) {
+            run           = false;
+            Qheat_scaling = 0.0;
+        }
+    }
 
-    if (nstep * time_step < (2 * M_PI / esp.insolation.get_mean_motion())) {
-        // stationary orbit/obliquity
-        // calculate annually average of insolation for the first orbit
-        annual_insol<<<NBRT, NTH>>>(insol_ann_d, insol_d, nstep, esp.point_num);
+    if (run) {
+        //
+        //  Number of threads per block.
+        const int NTH = 256;
+
+        //  Specify the block sizes.
+        dim3 NB((esp.point_num / NTH) + 1, esp.nv, 1);
+        dim3 NBRT((esp.point_num / NTH) + 1, 1, 1);
+
+        rtm_dual_band<<<NBRT, NTH>>>(esp.pressure_d,
+                                     esp.Rho_d,
+                                     esp.temperature_d,
+                                     flw_up_d,
+                                     flw_dn_d,
+                                     fsw_up_d,
+                                     fsw_dn_d,
+                                     tau_d,
+                                     sim.Gravit,
+                                     esp.Cp_d,
+                                     esp.lonlat_d,
+                                     esp.Altitude_d,
+                                     esp.Altitudeh_d,
+                                     phtemp,
+                                     dtemp,
+                                     ttemp,
+                                     thtemp,
+                                     time_step,
+                                     Tstar,
+                                     planet_star_dist,
+                                     radius_star,
+                                     diff_ang,
+                                     esp.Tint,
+                                     albedo,
+                                     tausw,
+                                     taulw,
+                                     latf_lw,
+                                     taulw_pole,
+                                     n_sw,
+                                     n_lw,
+                                     esp.f_lw,
+                                     incflx,
+                                     sim.P_Ref,
+                                     esp.point_num,
+                                     esp.nv,
+                                     esp.nvi,
+                                     sim.A,
+                                     esp.insolation.get_r_orb(),
+                                     esp.insolation.get_device_cos_zenith_angles(),
+                                     insol_d,
+                                     surface,
+                                     Csurf,
+                                     Tsurface_d,
+                                     surf_flux_d,
+                                     esp.profx_Qheat_d,
+                                     qheat_d,
+                                     esp.Rd_d,
+                                     Qheat_scaling,
+                                     sim.gcm_off,
+                                     rt1Dmode);
+
+        if (nstep * time_step < (2 * M_PI / esp.insolation.get_mean_motion())) {
+            // stationary orbit/obliquity
+            // calculate annually average of insolation for the first orbit
+            annual_insol<<<NBRT, NTH>>>(insol_ann_d, insol_d, nstep, esp.point_num);
+        }
     }
     return true;
 }
@@ -291,6 +342,13 @@ bool radiative_transfer::configure(config_file &config_reader) {
     config_reader.append_config_var("Csurf", Csurf_config, Csurf_config);
 
     config_reader.append_config_var("rt1Dmode", rt1Dmode_config, rt1Dmode_config);
+
+    // spin up spin down
+    config_reader.append_config_var("dgrt_spinup_start", spinup_start_step, spinup_start_step);
+    config_reader.append_config_var("dgrt_spinup_stop", spinup_stop_step, spinup_stop_step);
+    config_reader.append_config_var(
+        "dgrt_spindown_start", spindown_start_step, spindown_start_step);
+    config_reader.append_config_var("dgrt_spindown_stop", spindown_stop_step, spindown_stop_step);
 
     return true;
 }
@@ -334,6 +392,8 @@ bool radiative_transfer::store(const ESP &esp, storage &s) {
 
     cudaMemcpy(Tsurface_h, Tsurface_d, esp.point_num * sizeof(double), cudaMemcpyDeviceToHost);
     s.append_table(Tsurface_h, esp.point_num, "/Tsurface", "K", "surface temperature");
+
+    s.append_value(Qheat_scaling, "/dgrt_qheat_scaling", " ", "Qheat scaling applied to DG");
     return true;
 }
 


### PR DESCRIPTION
* fix Correct_Horizontal bincomp issue
* Alfrodull integrated as a C++ class in multi module, as "two_streams_radiative_transfer" class. under #ifdef enabled when makefile finds Alfrodull directory.
* makefile change to build Alf in multi (can get rid of "multi" and "empty" separate build as modules, next, for now, "empty" doesn't build, switching to model of having one physiccs module, with separate classes that can be built externaly. Physics is enabled/disabled by config file)
* Alfrodull and RT spin up and spin down parameters
* some config file configs added.
* mu_star wiggle as degrees increment instead of cos multiplicative factor.
* hamarr.py checks for "modules enabled" presence and value.
* hamarr.py has commented out field names for mu_star, zenith_angles, cos_zenith_angles while transitioning naming...