### PR TITLE
Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ $(OBJDIR)/${OUTPUTDIR}/$(DEPDIR): $(OBJDIR)/${OUTPUTDIR} $(OBJDIR)
 $(OBJDIR)/${OUTPUTDIR}/esp.o: esp.cu $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/esp.d $(GITREV_FILE) | $(OBJDIR)/${OUTPUTDIR}/$(DEPDIR) $(OBJDIR)/$(OUTPUTDIR) $(OBJDIR)
 	@echo -e '$(BLUE)creating dependencies for $@ $(END)'
 	set -e; rm -f $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/esp.d; \
-	$(CC) $(cuda_dependencies_flags) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) -I$(includedir)  -I$(OBJDIR) $(CDB) $(ALFRODULL_FLAGS) $< > $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/esp.d.$$$$; \
+	$(CC) $(cuda_dependencies_flags) $(arch)  $(cuda_flags) $(h5include) -I$(includedir)  -I$(OBJDIR) $(CDB) $(ALFRODULL_FLAGS) $< > $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/esp.d.$$$$; \
 	sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' < $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/esp.d.$$$$ > $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/esp.d; \
 	rm -f $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/esp.d.$$$$
 	@echo -e '$(YELLOW)creating object file for $@ $(END)'
@@ -306,7 +306,7 @@ $(OBJDIR)/${OUTPUTDIR}/esp.o: esp.cu $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/esp.d $(GI
 $(OBJDIR)/${OUTPUTDIR}/%.o: %.cu $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/%.d  | $(OBJDIR)/${OUTPUTDIR}/$(DEPDIR) $(OBJDIR)/$(OUTPUTDIR) $(OBJDIR) 
 	@echo -e '$(BLUE)creating dependencies for $@ $(END)'
 	set -e; rm -f $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/$*.d; \
-	$(CC) $(cuda_dependencies_flags) $(CC_comp_flag) $(arch)  $(cuda_flags) $(h5include) $(includeflags) $(CDB) $(ALFRODULL_FLAGS) $< > $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/$*.d.$$$$; \
+	$(CC) $(cuda_dependencies_flags) $(arch)  $(cuda_flags) $(h5include) $(includeflags) $(CDB) $(ALFRODULL_FLAGS) $< > $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/$*.d.$$$$; \
 	sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' < $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/$*.d.$$$$ > $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/$*.d; \
 	rm -f $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/$*.d.$$$$
 	@echo -e '$(YELLOW)creating object file for $@ $(END)'
@@ -316,7 +316,7 @@ $(OBJDIR)/${OUTPUTDIR}/%.o: %.cu $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/%.d  | $(OBJDI
 $(OBJDIR)/${OUTPUTDIR}/%.o: %.cpp $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/%.d  | $(OBJDIR)/${OUTPUTDIR}/$(DEPDIR) $(OBJDIR)/$(OUTPUTDIR) $(OBJDIR)
 	@echo -e '$(BLUE)creating dependencies for $@ $(END)'
 	set -e; rm -f $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/$*.d; \
-	$(CC) $(dependencies_flags) $(CC_comp_flag) $(arch)  $(cpp_flags) $(h5include) $(includeflags) $(CDB) $(ALFRODULL_FLAGS) $< > $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/$*.d.$$$$; \
+	$(CC) $(dependencies_flags) $(arch)  $(cpp_flags) $(h5include) $(includeflags) $(CDB) $(ALFRODULL_FLAGS) $< > $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/$*.d.$$$$; \
 	sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' < $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/$*.d.$$$$ > $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/$*.d; \
 	rm -f $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/$*.d.$$$$
 	@echo -e '$(YELLOW)creating object file for $@  $(END)'

--- a/Makefile
+++ b/Makefile
@@ -224,34 +224,41 @@ $(info CC compile flag: $(CC_comp_flag))
 
 
 #######################################################################
-# test for alfrodull radiative transfer physics class
-ifeq ($(wildcard Alfrodull),)
-	ALFRODULL_FLAGS =
-	ALFCLASS = 
-	ALFRODULL_LINK_FLAGS =
-	ALFRODULL_TARGET = 
-else
-	ALFRODULL_FLAGS = -DHAS_ALFRODULL=1 -IAlfrodull/thor_module/inc/ -IAlfrodull/src/inc
-	ALFCLASS = Alfrodull/thor_module/inc/two_stream_radiative_transfer.h
-	ALFRODULL_LINK_FLAGS =  -LAlfrodull -lalfrodull
-	ALFRODULL_TARGET = Alfrodull/libalfrodull.a
-	ALFRODULL_DEP = Alfrodull
-	ALFRODULL_CLEAN_DEP = Alfrodull_clean
-export
-# always call submakefile for alf
-.PHONY: Alfrodull
-Alfrodull:
-	@echo -e '$(MAGENTA)Creating Alfrodull from subdir Alfrodull$(END)'
-	$(MAKE) -f Makefile -C Alfrodull
+# Test for alfrodull radiative transfer physics class
+# Defining Alfrodull build variables if present
+ifneq ($(wildcard Alfrodull/*),)
+    $(info Alfrodull directory not empty, try to build with Alfrodull)
+    ALFRODULL_FLAGS = -DHAS_ALFRODULL=1 -IAlfrodull/thor_module/inc/ -IAlfrodull/src/inc
+    ALFCLASS = Alfrodull/thor_module/inc/two_stream_radiative_transfer.h
+    ALFRODULL_LINK_FLAGS =  -LAlfrodull -lalfrodull
+    ALFRODULL_TARGET = Alfrodull/libalfrodull.a
+    ALFRODULL_DEP = Alfrodull
+    ALFRODULL_CLEAN_DEP = Alfrodull_clean
 
-.PHONY: Alfrodull_clean
-Alfrodull_clean:
-	@echo -e '$(MAGENTA)Cleaning Alfrodull$(END)'
-	$(MAKE) -f Makefile -C Alfrodull clean
+    export
+
+    # always call submakefile for alf
+    .PHONY: Alfrodull
+    Alfrodull:
+		@echo -e '$(MAGENTA)Creating Alfrodull from subdir Alfrodull$(END)'
+		$(MAKE) -f Makefile -C Alfrodull
+
+    .PHONY: Alfrodull_clean
+    Alfrodull_clean:
+		@echo -e '$(MAGENTA)Cleaning Alfrodull$(END)'
+		$(MAKE) -f Makefile -C Alfrodull clean
+else
+    $(info No Alfrodull directory or empty directory, building without Alfrodull)
+    ALFRODULL_FLAGS =
+    ALFCLASS = 
+    ALFRODULL_LINK_FLAGS =
+    ALFRODULL_TARGET =
+    ALFRODULL_DEP =
+    ALFRODULL_CLEAN_DEP =
 endif 
 
 
-$(info alf flags: $(ALFRODULL_FLAGS))
+$(info alf flags: $(ALFRODULL_FLAGS) deps $(ALFRODULL_CLEAN_DEP))
 
 #######################################################################
 
@@ -381,7 +388,7 @@ $(BINDIR)/$(TESTDIR)/reduction_add_test:  $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(
 
 #######################################################################
 # Cleanup
-.phony: clean,ar
+.PHONY: clean,ar
 clean: $(ALFRODULL_CLEAN_DEP)
 	@echo -e '$(CYAN)clean up binaries $(END)'
 	-$(RM) $(BINDIR)/debug/esp

--- a/Makefile
+++ b/Makefile
@@ -314,9 +314,6 @@ $(OBJDIR)/${OUTPUTDIR}/%.o: %.cpp $(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/%.d  | $(OBJD
 	@echo -e '$(YELLOW)creating dependencies and object file for $@  $(END)'
 	$(CC) $(dependencies_flags) $(CC_comp_flag) $(arch) $(cpp_flags) $(h5include) $(includeflags) $(CDB) $(ALFRODULL_FLAGS) -o $@ $<
 
-# Target for dependencies, so that they are always defined
-$(OBJDIR)/${OUTPUTDIR}/${DEPDIR}/%.d: ;
-
 # link *.o objects
 .PHONY: 
 $(BINDIR)/${OUTPUTDIR}/esp: $(addprefix $(OBJDIR)/$(OUTPUTDIR)/,$(obj)) $(ALFRODULL_DEP) | $(BINDIR) $(RESDIR) $(BINDIR)/$(OUTPUTDIR)  $(OBJDIR)
@@ -338,7 +335,7 @@ symlink: $(BINDIR)/$(OUTPUTDIR)/esp   | $(OBJDIR) $(GITREV_FILE)
 	ln -s $(BINDIR)/$(OUTPUTDIR)/esp -r -t bin
 
 # dependencies
-DEPFILES := $($(obj):%.o=$(OBJDIR)/$(OUTPUTDIR)/$(DEPDIR)/%.d)
+DEPFILES := $(obj:%.o=$(OBJDIR)/$(OUTPUTDIR)/$(DEPDIR)/%.d)
 $(DEPFILES):
 
 #######################################################################

--- a/ifile/alf_wasp_alf.thr
+++ b/ifile/alf_wasp_alf.thr
@@ -353,7 +353,8 @@ Alf_compute_every_nstep = 1
 #########################################################
 # spin up and spin down start and stop. Set to negative value to ignore and run at full power
 # spins up/down with a multiplication factor following a sine from 0 to 1 from
-# start to stop of spin up time
+# start to stop of spin up time and a sine from 1 to 0 for spin down
+# can be used in parallel with double grey radiative transfer above for faster spinup
 Alf_spinup_start = 10
 Alf_spinup_stop = 20
 Alf_spindown_start = -1


### PR DESCRIPTION
* makefile now builds multi module which is integrated into THOR. No separate physics compilation anymore. 
* makefile compatible to CUDA toolkit < 10, tested with cuda 9. Done by using the old way of generating dependency files.
* fix some stuff related to alfrodull compile. If Alfrodull directory is not present, it doesn't try to build Alf. and sets the preprocessor define to disable alf in multi module.
* comment in alf example init file