### PR TITLE
Restructured python objects, output of qheat

### DIFF
--- a/mjolnir/hamarr.py
+++ b/mjolnir/hamarr.py
@@ -56,8 +56,6 @@ class input_new:
 
         for key in openh5.keys():
             setattr(self,key,openh5[key][...])
-        self.NonHydro = openh5['NonHydro'][0]
-        self.DeepModel = openh5['DeepModel'][0]
 
         #special cases (things we test on a lot, etc)
         self.RT = "radiative_transfer" in openh5 and openh5["radiative_transfer"][0] == 1.0
@@ -158,20 +156,24 @@ class output_new:
 
         # dictionary of field variables (2-D or 3-D arrays)
         # key is the key in h5 file, value is desired attribute name in this class
-        outputs = {'Rho': 'Rho', 'Pressure': 'Pressure', 'Mh': 'Mh', 'Wh': 'Wh',
-                    'Rho_mean': 'Rho_mean', 'Pressure_mean': 'Pressure_mean',
-                    'Mh_mean': 'Mh_mean', 'Wh_mean': 'Wh_mean'}
+        outputs = {'Rho': 'Rho', 'Pressure': 'Pressure', 'Mh': 'Mh', 'Wh': 'Wh'}
+
+        if input.output_mean:
+            outputs['Rho_mean'] = 'Rho_mean'
+            outputs['Pressure_mean'] = 'Pressure_mean'
+            outputs['Mh_mean'] = 'Mh_mean'
+            outputs['Wh_mean'] = 'Wh_mean'
 
         #add things to outputs that can be checked for in input or grid
-        if input.RT or input.TSRT:
-            outputs['Qheat'] = 'qheat'
+        # if input.RT or input.TSRT:
+        #     outputs['Qheat'] = 'qheat'
 
         if input.RT:
             outputs['tau'] = 'tau'  #have to be careful about slicing this (sw = ::2, lw = 1::2)
             outputs['flw_up'] = 'flw_up'
             outputs['flw_dn'] = 'flw_dn'
             outputs['fsw_dn'] = 'fsw_dn'
-            outputs['DGQheat'] = 'DGqheat'
+            # outputs['DGQheat'] = 'DGqheat'
 
         if input.TSRT:
             outputs['F_up_tot'] = 'f_up_tot'
@@ -201,6 +203,10 @@ class output_new:
 
             if t == ntsi - 1:
                 # add things to outputs dictionary that require checking for existence in openh5
+                if 'Qheat' in openh5.keys():
+                    outputs['Qheat'] = 'qheat'
+                if 'DGQheat' in openh5.keys():
+                    outputs['DGQheat'] = 'DGQheat'
                 if 'Etotal' in openh5.keys():
                     self.ConvData[t-ntsi+1] = True
                     outputs['Etotal'] = 'Etotal'

--- a/mjolnir/hamarr.py
+++ b/mjolnir/hamarr.py
@@ -1,8 +1,16 @@
+#---- code by Russell Deitrick and Urs Schroffenegger -------------------------
+
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.colors as colors
 import matplotlib.axes as axes
 import matplotlib.cm as cm
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+from matplotlib.colors import hsv_to_rgb
+import matplotlib.patheffects as pe
+
+import math
+
 import scipy.interpolate as interp
 import scipy.ndimage as ndimage
 import os
@@ -11,6 +19,10 @@ import time
 import subprocess as spr
 import pyshtools as chairs
 import pdb
+
+import pathlib
+import psutil
+
 try:
     import pycuda.driver as cuda
     import pycuda.autoinit
@@ -26,78 +38,48 @@ plt.rcParams['image.cmap'] = 'magma'
 # plt.rcParams['font.sans-serif'] = 'Helvetica-Normal'
 
 
-class input:
+
+class input_new:
     def __init__(self, resultsf, simID):
         fileh5 = resultsf + '/esp_output_planet_' + simID + '.h5'
         if os.path.exists(fileh5):
-            openh5 = h5py.File(fileh5)
+            openh5 = h5py.File(fileh5,'r')
         else:
             fileh5_old = resultsf + '/esp_output_' + simID + '.h5'
             if os.path.exists(fileh5_old):
-                openh5 = h5py.File(fileh5_old)
+                openh5 = h5py.File(fileh5_old,'r')
             else:
                 raise IOError(fileh5 + ' or ' + fileh5_old + ' not found!')
-        self.A = openh5['A'][...]  # 'A' is the key for this dataset
-        # [...] is syntax for "gimme all the data under this key"
-        self.Rd = openh5['Rd'][...]
-        self.Omega = openh5['Omega'][...]
-        self.P_Ref = openh5['P_Ref'][...]
-        self.Top_altitude = openh5['Top_altitude'][...]
-        self.Cp = openh5['Cp'][...]
-        self.Gravit = openh5['Gravit'][...]
-        if 'spring_beta' in openh5.keys():
-            self.spring_beta = openh5['spring_beta'][...]
-            self.vlevel = openh5['vlevel'][...]
-            self.glevel = openh5['glevel'][...]
-            self.spring_dynamics = openh5['spring_dynamics'][...]
+
         self.resultsf = resultsf
         self.simID = simID
+
+        for key in openh5.keys():
+            setattr(self,key,openh5[key][...])
         self.NonHydro = openh5['NonHydro'][0]
         self.DeepModel = openh5['DeepModel'][0]
 
-        if 'SpongeLayer' in openh5.keys():
-            self.SpongeLayer = openh5['SpongeLayer'][...]
-            if self.SpongeLayer[0] == 1:
-                self.nlat = openh5['nlat'][...]
-                self.ns_sponge = openh5['ns_sponge'][...]
-                self.Rv_sponge = openh5['Rv_sponge'][...]
-        if 'hstest' in openh5.keys():
-            self.core_benchmark = openh5['hstest'][...]
-        else:
-            self.core_benchmark = openh5['core_benchmark'][...]
-
-        self.RT = "radiative_transfer" in openh5
-        if self.RT:
-            self.Tstar = openh5['Tstar'][...]
-            self.planet_star_dist = openh5['planet_star_dist'][...]
-            self.radius_star = openh5['radius_star'][...]
-            if 'diff_fac' in openh5.keys():  # called diff_fac in old versions
-                self.diff_ang = openh5['diff_fac'][...]
-            else:
-                self.diff_ang = openh5['diff_ang'][...]
-            if 'Tint' in openh5.keys():
-                self.Tint = openh5['Tint'][...]
-            self.albedo = openh5['albedo'][...]
-            self.tausw = openh5['tausw'][...]
-            self.taulw = openh5['taulw'][...]
-            if 'surface' in openh5.keys():
-                self.surface = openh5['surface'][0]
-            else:
-                self.surface = 0
-
-        self.TSRT = "two_streams_radiative_transfer" in openh5
+        #special cases (things we test on a lot, etc)
+        self.RT = "radiative_transfer" in openh5 and openh5["radiative_transfer"][0] == 1.0
+        self.TSRT = "two_streams_radiative_transfer" in openh5 and openh5["two_streams_radiative_transfer"][0] == 1.0
         if self.TSRT:
-            self.Tstar = openh5['Tstar'][...]
-            self.planet_star_dist = openh5['planet_star_dist'][...]
-            self.radius_star = openh5['radius_star'][...]
+            if 'alf_w0_g0_per_band' in openh5 and openh5['alf_w0_g0_per_band'][0] == 1.0:
+                self.has_w0_g0 = True
+            else:
+                self.has_w0_g0 = False
+        else:
+            self.has_w0_g0 = False
 
-        if 'vulcan' in openh5.keys():
-            self.chemistry = openh5['vulcan'][...]
-        if 'chemistry' in openh5.keys():
-            self.chemistry = openh5['chemistry'][...]
+        self.chemistry = "chemistry" in openh5 and openh5["chemistry" ][0] == 1
 
+        if not hasattr(self,'surface'):
+            self.surface = False
+        #some bw compatibility things
+        if hasattr(self,'vulcan'):
+            self.chemistry = self.vulcan
+        if hasattr(self,'diff_fac'):
+            self.diff_ang = self.diff_fac
         openh5.close()
-
 
 def LatLong2Cart(lat, lon):
     x = np.cos(lat) * np.cos(lon)
@@ -123,80 +105,83 @@ def Rot_z(phi, x, y, z):
     ynew = np.sin(phi) * x + np.cos(phi) * y
     return xnew, ynew, z
 
-
-class grid:
+class grid_new:
     def __init__(self, resultsf, simID, rotation=False, theta_y=0, theta_z=0):
         fileh5 = resultsf + '/esp_output_grid_' + simID + '.h5'
         if os.path.exists(fileh5):
-            openh5 = h5py.File(fileh5)
+            openh5 = h5py.File(fileh5,'r')
         else:
             raise IOError(fileh5 + ' not found!')
-        self.Altitude = openh5['Altitude'][...]
-        self.Altitudeh = openh5['Altitudeh'][...]
-        self.areasT = openh5['areasT'][...]
-        self.lonlat = openh5['lonlat'][...]
+
         self.point_num = np.int(openh5['point_num'][0])
-        self.pntloc = np.reshape(openh5['pntloc'][...], (self.point_num, 6))  # indices of nearest neighbors
         self.nv = np.int(openh5['nv'][0])
-        if 'grad' in openh5.keys():
-            self.grad = np.reshape(openh5['grad'][...], (self.point_num, 7, 3))
-            self.div = np.reshape(openh5['div'][...], (self.point_num, 7, 3))
-        if 'curlz' in openh5.keys():
-            self.curlz = np.reshape(openh5['curlz'][...], (self.point_num, 7, 3))
-        openh5.close()
         self.nvi = self.nv + 1
-        self.lon = (self.lonlat[::2]) % (2 * np.pi)
-        self.lat = self.lonlat[1::2]
-        if rotation == True:
-            xtmp, ytmp, ztmp = LatLong2Cart(self.lat, self.lon)
-            xtmp1, ytmp1, ztmp1 = Rot_z(theta_z, xtmp, ytmp, ztmp)
-            xtmp2, ytmp2, ztmp2 = Rot_y(theta_y, xtmp1, ytmp1, ztmp1)
-            self.lat, self.lon = Cart2LatLong(xtmp2, ytmp2, ztmp2)
-            self.lon = self.lon % (2 * np.pi)
+        for key in openh5.keys():
+            if key != 'nv' and key != 'point_num':
+                if key == 'pntloc':
+                    setattr(self,key,np.reshape(openh5[key][...],(self.point_num,6)))
+                elif key == 'grad' or key == 'div' or key == 'curlz':
+                    setattr(self,key,np.reshape(openh5[key][...],(self.point_num,7,3)))
+                elif key == 'lonlat':
+                    self.lon = (openh5[key][::2]) % (2*np.pi)
+                    self.lat = openh5[key][1::2]
+                    if rotation == True:
+                        xtmp, ytmp, ztmp = LatLong2Cart(self.lat, self.lon)
+                        xtmp1, ytmp1, ztmp1 = Rot_z(theta_z, xtmp, ytmp, ztmp)
+                        xtmp2, ytmp2, ztmp2 = Rot_y(theta_y, xtmp1, ytmp1, ztmp1)
+                        self.lat, self.lon = Cart2LatLong(xtmp2, ytmp2, ztmp2)
+                        self.lon = self.lon % (2 * np.pi)
+                else:
+                    setattr(self,key,openh5[key][...])
+        openh5.close()
 
-
-class output:
+class output_new:
     def __init__(self, resultsf, simID, ntsi, nts, input, grid, stride=1):
-        # Initialize arrays
-        self.Rho = np.zeros((grid.point_num, grid.nv, nts - ntsi + 1))
-        self.Pressure = np.zeros((grid.point_num, grid.nv, nts - ntsi + 1))
-        self.Mh = np.zeros((3, grid.point_num, grid.nv, nts - ntsi + 1))
-        self.Wh = np.zeros((grid.point_num, grid.nvi, nts - ntsi + 1))
+        #need to test best way to read/create virtual dataset
+        #if I read in source files with "r", I need to close the virtual data file
+        # and then reopen it with "r" to make data visible
+        #if I read in source files with "r+", there is no need to close and reopen
+
+        #some basic info
         self.ntsi = ntsi
         self.nts = nts
+        # 1-D arrays
         self.time = np.zeros(nts - ntsi + 1)
         self.nstep = np.zeros(nts - ntsi + 1)
-        self.Etotal = np.zeros((grid.point_num, grid.nv, nts - ntsi + 1))
-        self.Entropy = np.zeros((grid.point_num, grid.nv, nts - ntsi + 1))
-        self.Mass = np.zeros((grid.point_num, grid.nv, nts - ntsi + 1))
-        self.AngMomx = np.zeros((grid.point_num, grid.nv, nts - ntsi + 1))
-        self.AngMomy = np.zeros((grid.point_num, grid.nv, nts - ntsi + 1))
-        self.AngMomz = np.zeros((grid.point_num, grid.nv, nts - ntsi + 1))
+        self.ConvData = np.zeros(nts - ntsi + 1)
         self.GlobalE = np.zeros(nts - ntsi + 1)
         self.GlobalEnt = np.zeros(nts - ntsi + 1)
         self.GlobalMass = np.zeros(nts - ntsi + 1)
         self.GlobalAMx = np.zeros(nts - ntsi + 1)
         self.GlobalAMy = np.zeros(nts - ntsi + 1)
         self.GlobalAMz = np.zeros(nts - ntsi + 1)
-        self.ConvData = np.zeros(nts - ntsi + 1)
-        self.EntData = np.zeros(nts - ntsi + 1)
-        self.Insol = np.zeros((grid.point_num, nts - ntsi + 1))
-        self.Tsurface = np.zeros((grid.point_num, nts - ntsi + 1))
 
-        self.ch4 = np.zeros((grid.point_num, grid.nv, nts - ntsi + 1))
-        self.co = np.zeros((grid.point_num, grid.nv, nts - ntsi + 1))
-        self.h2o = np.zeros((grid.point_num, grid.nv, nts - ntsi + 1))
-        self.co2 = np.zeros((grid.point_num, grid.nv, nts - ntsi + 1))
-        self.nh3 = np.zeros((grid.point_num, grid.nv, nts - ntsi + 1))
+        # dictionary of field variables (2-D or 3-D arrays)
+        # key is the key in h5 file, value is desired attribute name in this class
+        outputs = {'Rho': 'Rho', 'Pressure': 'Pressure', 'Mh': 'Mh', 'Wh': 'Wh',
+                    'Rho_mean': 'Rho_mean', 'Pressure_mean': 'Pressure_mean',
+                    'Mh_mean': 'Mh_mean', 'Wh_mean': 'Wh_mean'}
 
-        self.tau_sw = np.zeros((grid.point_num, grid.nv, nts - ntsi + 1))
-        self.tau_lw = np.zeros((grid.point_num, grid.nv, nts - ntsi + 1))
-        self.flw_up = np.zeros((grid.point_num, grid.nvi, nts - ntsi + 1))
-        self.flw_dn = np.zeros((grid.point_num, grid.nvi, nts - ntsi + 1))
-        self.fsw_dn = np.zeros((grid.point_num, grid.nvi, nts - ntsi + 1))
+        #add things to outputs that can be checked for in input or grid
+        if input.RT or input.TSRT:
+            outputs['Qheat'] = 'qheat'
 
-        self.Rd = np.zeros((grid.point_num, grid.nv, nts - ntsi + 1))
-        self.Cp = np.zeros((grid.point_num, grid.nv, nts - ntsi + 1))
+        if input.RT:
+            outputs['tau'] = 'tau'  #have to be careful about slicing this (sw = ::2, lw = 1::2)
+            outputs['flw_up'] = 'flw_up'
+            outputs['flw_dn'] = 'flw_dn'
+            outputs['fsw_dn'] = 'fsw_dn'
+            outputs['DGQheat'] = 'DGqheat'
+
+        if input.TSRT:
+            outputs['F_up_tot'] = 'f_up_tot'
+            outputs['F_down_tot'] = 'f_down_tot'
+            outputs['F_dir_tot'] = 'f_dir_tot'
+            outputs['F_net'] = 'f_net'
+            outputs['Alf_Qheat'] = 'TSqheat'
+            outputs['F_up_TOA_spectrum'] = 'spectrum'
+            outputs['alf_spectrum'] = 'incoming_spectrum'
+            outputs['lambda_wave'] = 'wavelength'
 
         # calc volume element
         Atot = input.A**2
@@ -205,126 +190,147 @@ class output:
             rint = ((input.A + grid.Altitudeh[1:])**3 - (input.A + grid.Altitudeh[:-1])**3) / 3.0
         else:
             rint = Atot*(grid.Altitudeh[1:] - grid.Altitudeh[:-1])
-        Vol0 = solid_ang[:, None] * rint[None, :]
+        self.Vol0 = solid_ang[:, None] * rint[None, :]
 
-        # TSRT quantities
-        # TODO: clean up what's only for debug
-        self.f_up_tot = np.zeros((grid.point_num, grid.nvi, nts - ntsi + 1))
-        self.f_down_tot = np.zeros((grid.point_num, grid.nvi, nts - ntsi + 1))
-        self.f_net = np.zeros((grid.point_num, grid.nvi, nts - ntsi + 1))
-        self.q_heat = np.zeros((grid.point_num, grid.nv, nts - ntsi + 1))
-        self.mustar = np.zeros((grid.point_num, nts - ntsi + 1))
-        # Read model results
         for t in np.arange(ntsi - 1, nts, stride):
             fileh5 = resultsf + '/esp_output_' + simID + '_' + np.str(t + 1) + '.h5'
             if os.path.exists(fileh5):
-                openh5 = h5py.File(fileh5)
+                openh5 = h5py.File(fileh5, 'r+')
             else:
                 raise IOError(fileh5 + ' not found!')
 
-            Rhoi = openh5['Rho'][...]
-            Pressurei = openh5['Pressure'][...]
-            Mhi = openh5['Mh'][...]
-            Whi = openh5['Wh'][...]
-            time = openh5['simulation_time'][0] / 86400
-            nstep = openh5['nstep'][0]
+            if t == ntsi - 1:
+                # add things to outputs dictionary that require checking for existence in openh5
+                if 'Etotal' in openh5.keys():
+                    self.ConvData[t-ntsi+1] = True
+                    outputs['Etotal'] = 'Etotal'
+                    outputs['Mass'] = 'Mass'
+                    outputs['AngMomx'] = 'AngMomx'
+                    outputs['AngMomy'] = 'AngMomy'
+                    outputs['AngMomz'] = 'AngMomz'
+                    outputs['Entropy'] = 'Entropy'
+                else:
+                    print('Warning: conservation diagnostics not available in file %s' % fileh5)
+                    self.ConvData[t-ntsi+1] = False
 
-            if 'Rd' in openh5.keys():
-                Rdi = openh5['Rd'][...]
-                Cpi = openh5['Cp'][...]
-            else:
-                Rdi = np.zeros_like(Rhoi) + input.Rd
-                Cpi = np.zeros_like(Rhoi) + input.Cp
+                if 'insol' in openh5.keys():
+                    outputs['insol'] = 'Insol'
+                if 'tracer' in openh5.keys():
+                    outputs['tracer'] = 'tracer' #ch4 ::5, co 1::5, h2o 2::5, co2 3::5, nh3 4::5
+                if 'Tsurface' in openh5.keys():
+                    outputs['Tsurface'] = 'Tsurface'
+                if 'Rd' in openh5.keys():
+                    self.ConstRdCp = False
+                    outputs['Rd'] = 'Rd'
+                    outputs['Cp'] = 'Cp'
+                else:
+                    self.ConstRdCp = True
 
-            if 'Etotal' in openh5.keys():
-                Etotali = openh5['Etotal'][...]
-                Massi = openh5['Mass'][...]
-                AngMomxi = openh5['AngMomx'][...]
-                AngMomyi = openh5['AngMomy'][...]
-                AngMomzi = openh5['AngMomz'][...]
+                # for rename transition of col_mu_star, can be removed later
+                if 'cos_zenith_angles' in openh5.keys():
+                    outputs['cos_zenith_angles'] = 'mustar'
+                elif 'zenith_angles' in openh5.keys():
+                    outputs['zenith_angles'] = 'mustar'
+                elif 'col_mu_star' in openh5.keys():
+                    outputs['col_mu_star'] = 'mustar'
+
+                if input.TSRT:
+                    if 'w0_band' in openh5.keys():
+                        outputs['w0_band'] = 'w0_band'
+                    if 'g0_band' in openh5.keys():
+                        outputs['g0_band'] = 'g0_band'
+
+                #create VDS layout shape
+                for key in outputs.keys():
+                    setattr(self, outputs[key]+'_lo', h5py.VirtualLayout(shape=
+                                (np.shape(openh5[key])[0],nts-ntsi+1),dtype='f8'))
+
+            #shove source reference into layout
+            for key in outputs.keys():
+                getattr(self, outputs[key]+'_lo')[:,t-ntsi+1] = h5py.VirtualSource(openh5[key])
+
+            # 1-D arrays, unlikely to overflow memory
+            self.time[t-ntsi+1] = openh5['simulation_time'][0] / 86400
+            self.nstep[t-ntsi+1] = openh5['nstep'][0]
+            if self.ConvData[t-ntsi+1]:
                 self.GlobalE[t - ntsi + 1] = openh5['GlobalE'][0]
                 self.GlobalMass[t - ntsi + 1] = openh5['GlobalMass'][0]
                 self.GlobalAMx[t - ntsi + 1] = openh5['GlobalAMx'][0]
                 self.GlobalAMy[t - ntsi + 1] = openh5['GlobalAMy'][0]
                 self.GlobalAMz[t - ntsi + 1] = openh5['GlobalAMz'][0]
-                self.ConvData[t - ntsi + 1] = True
-            else:
-                print('Warning: conservation diagnostics not available in file %s' % fileh5)
-                self.ConvData[t - ntsi + 1] = False
-            if 'Entropy' in openh5.keys():
-                Entropyi = openh5['Entropy'][...]
                 self.GlobalEnt[t - ntsi + 1] = openh5['GlobalEnt'][0]
-                self.EntData[t - ntsi + 1] = True
-            else:
-                print('Warning: entropy not available in file %s' % fileh5)
-                self.EntData[t - ntsi + 1] = False
-            if 'insol' in openh5.keys():
-                self.Insol[:, t - ntsi + 1] = openh5['insol'][...]
-            if 'tracer' in openh5.keys():
-                traceri = openh5['tracer'][...]
-            if 'tau' in openh5.keys():
-                taui = openh5['tau'][...]
-                if 'fnet_up' in openh5.keys():  # old version of LW output
-                    fupi = openh5['fnet_up'][...]
-                    fdni = openh5['fnet_dn'][...]
-                    sdni = np.zeros_like(fdni)
-                else:
-                    fupi = openh5['flw_up'][...]
-                    fdni = openh5['flw_dn'][...]
-                    sdni = openh5['fsw_dn'][...]
-            if 'Tsurface' in openh5.keys():
-                self.Tsurface[:, t - ntsi + 1] = openh5['Tsurface'][...]
-            if input.TSRT:
-                f_up_tot_i = openh5['F_up_tot'][...]
-                f_down_tot_i = openh5['F_down_tot'][...]
-                f_net_i = openh5['F_net'][...]
-                q_heat_i = openh5['Alf_Qheat'][...]
-                self.mustar[:, t - ntsi + 1] = openh5['col_mu_star'][...]
+
             openh5.close()
 
-            self.Rho[:, :, t - ntsi + 1] = np.reshape(Rhoi, (grid.point_num, grid.nv))
-            self.Pressure[:, :, t - ntsi + 1] = np.reshape(Pressurei, (grid.point_num, grid.nv))
-            self.Mh[0, :, :, t - ntsi + 1] = np.reshape(Mhi[::3], (grid.point_num, grid.nv))
-            self.Mh[1, :, :, t - ntsi + 1] = np.reshape(Mhi[1::3], (grid.point_num, grid.nv))
-            self.Mh[2, :, :, t - ntsi + 1] = np.reshape(Mhi[2::3], (grid.point_num, grid.nv))
-            self.Wh[:, :, t - ntsi + 1] = np.reshape(Whi, (grid.point_num, grid.nvi))
-            self.Rd[:, :, t - ntsi + 1] = np.reshape(Rdi, (grid.point_num, grid.nv))
-            self.Cp[:, :, t - ntsi + 1] = np.reshape(Cpi, (grid.point_num, grid.nv))
+        fileVDS = resultsf+'/esp_output_'+simID+'_'+str(ntsi)+'_'+str(nts)+'_VDS.h5'
+        self.openVDS = h5py.File(fileVDS,'w',libver='latest')
 
-            self.time[t - ntsi + 1] = time
-            self.nstep[t - ntsi + 1] = nstep
-            if 'Etotali' in locals():
-                self.Etotal[:, :, t - ntsi + 1] = np.reshape(Etotali, (grid.point_num, grid.nv))/Vol0
-                self.Mass[:, :, t - ntsi + 1] = np.reshape(Massi, (grid.point_num, grid.nv))/Vol0
-                self.AngMomx[:, :, t - ntsi + 1] = np.reshape(AngMomxi, (grid.point_num, grid.nv))/Vol0
-                self.AngMomy[:, :, t - ntsi + 1] = np.reshape(AngMomyi, (grid.point_num, grid.nv))/Vol0
-                self.AngMomz[:, :, t - ntsi + 1] = np.reshape(AngMomzi, (grid.point_num, grid.nv))/Vol0
-            if 'Entropyi' in locals():
-                self.Entropy[:, :, t - ntsi + 1] = np.reshape(Entropyi, (grid.point_num, grid.nv))/Vol0
+        #create data sets.
+        #will need to reshape them (grid.point_num,grid.nv,nts-ntsi+1) in mjolnir
+        #self .Pressure = self.openVDS.create_virtual_dataset('Pressure',Pressure_lo,fillvalue=0)
+        for key in outputs.keys():
+            setattr(self, outputs[key], self.openVDS.create_virtual_dataset(outputs[key],getattr(self, outputs[key]+'_lo'),fillvalue=0))
 
-            if 'traceri' in locals():
-                self.ch4[:, :, t - ntsi + 1] = np.reshape(traceri[::5], (grid.point_num, grid.nv)) / self.Rho[:, :, t - ntsi + 1]
-                self.co[:, :, t - ntsi + 1] = np.reshape(traceri[1::5], (grid.point_num, grid.nv)) / self.Rho[:, :, t - ntsi + 1]
-                self.h2o[:, :, t - ntsi + 1] = np.reshape(traceri[2::5], (grid.point_num, grid.nv)) / self.Rho[:, :, t - ntsi + 1]
-                self.co2[:, :, t - ntsi + 1] = np.reshape(traceri[3::5], (grid.point_num, grid.nv)) / self.Rho[:, :, t - ntsi + 1]
-                self.nh3[:, :, t - ntsi + 1] = np.reshape(traceri[4::5], (grid.point_num, grid.nv)) / self.Rho[:, :, t - ntsi + 1]
+    # for use at end of plotting... closes h5 file with virtual data set
+    def closeVDS(self):
+        self.openVDS.close()
 
-            if 'taui' in locals():
-                self.tau_sw[:, :, t - ntsi + 1] = np.reshape(taui[::2], (grid.point_num, grid.nv))
-                self.tau_lw[:, :, t - ntsi + 1] = np.reshape(taui[1::2], (grid.point_num, grid.nv))
-                self.flw_dn[:, :, t - ntsi + 1] = np.reshape(fdni, (grid.point_num, grid.nvi))
-                self.flw_up[:, :, t - ntsi + 1] = np.reshape(fupi, (grid.point_num, grid.nvi))
-                self.fsw_dn[:, :, t - ntsi + 1] = np.reshape(sdni, (grid.point_num, grid.nvi))
+    #loads arrays from disk into memory and reshapes them (destroys reference to virtual data set)
+    def load_reshape(self,grid,keys):
+        tlen = self.nts-self.ntsi+1
+        for key in keys:
+            if key in self.openVDS.keys():
+                data_ref = getattr(self, key)
+                if isinstance(data_ref,h5py.Dataset):
+                    if data_ref.size*8 > psutil.virtual_memory().available:
+                        raise IOError("Dataset %s too large for memory; not loading"%key)
+                    data = data_ref[...]
+                    if np.shape(data) == (grid.point_num*grid.nv,tlen):
+                        data = np.reshape(data,(grid.point_num,grid.nv,tlen))
+                    elif np.shape(data) == (grid.point_num*grid.nvi,tlen):
+                        data = np.reshape(data,(grid.point_num,grid.nvi,tlen))
+                    # need to handle special formats (Mh, tracers...)
+                    elif np.shape(data) == (grid.point_num*grid.nv*3,tlen):
+                        data_new = np.zeros((3,grid.point_num,grid.nv,tlen))
+                        data_new[0] = np.reshape(data[::3],(grid.point_num,grid.nv,tlen))
+                        data_new[1] = np.reshape(data[1::3],(grid.point_num,grid.nv,tlen))
+                        data_new[2] = np.reshape(data[2::3],(grid.point_num,grid.nv,tlen))
+                        data = data_new
+                    if key == 'tracer':  #special case for passive tracers
+                        self.ch4 = np.reshape(data[::5],(grid.point_num,grid.nv,tlen))
+                        self.co = np.reshape(data[1::5],(grid.point_num,grid.nv,tlen))
+                        self.h2o = np.reshape(data[2::5],(grid.point_num,grid.nv,tlen))
+                        self.co2 = np.reshape(data[3::5],(grid.point_num,grid.nv,tlen))
+                        self.nh3 = np.reshape(data[4::5],(grid.point_num,grid.nv,tlen))
+                    elif key == 'tau':
+                        self.tau_sw = np.reshape(data[::2],(grid.point_num,grid.nv,tlen))
+                        self.tau_lw = np.reshape(data[1::2],(grid.point_num,grid.nv,tlen))
+                    elif key == 'spectrum':
+                        self.spectrum = np.reshape(data, (grid.point_num,-1,tlen))
+                    elif key == 'incoming_spectrum':
+                        self.incoming_spectrum = np.reshape(data, (-1,tlen))
+                    elif key == 'w0_band':
+                        self.w0_band = np.reshape(data, (grid.point_num,grid.nv,-1,tlen))
+                    elif key == 'g0_band':
+                        self.g0_band = np.reshape(data, (grid.point_num,grid.nv,-1,tlen))
+                    elif key == 'Etotal' or key == 'Entropy' or key == 'AngMomz':
+                        data = np.reshape(data,(grid.point_num,grid.nv,tlen))/self.Vol0[:,:,None]
+                        setattr(self, key, data)
+                    else:
+                        setattr(self, key, data)
+                else:
+                    print("Dataset %s has already been loaded into memory"%key)
+            else:
+                raise IOError("Invalid data set specified: %s"%key)
 
-            if input.TSRT:
-                self.f_up_tot[:, :, t - ntsi + 1] = np.reshape(f_up_tot_i, (grid.point_num, grid.nvi))
-                self.f_down_tot[:, :, t - ntsi + 1] = np.reshape(f_down_tot_i, (grid.point_num, grid.nvi))
-                self.f_net[:, :, t - ntsi + 1] = np.reshape(f_net_i, (grid.point_num, grid.nvi))
-                self.q_heat[:, :, t - ntsi + 1] = np.reshape(q_heat_i, (grid.point_num, grid.nv))
+    def load_reshape_all(self,grid):
+        keys = self.openVDS.keys()
+        self.load_reshape(grid,keys)
+        self.closeVDS()
 
 
-class rg_out:
-    def __init__(self, resultsf, simID, ntsi, nts, input, output, grid, pressure_vert=True, pgrid_ref='auto'):
+class rg_out_new:
+    def __init__(self, resultsf, simID, ntsi, nts, input, grid, pressure_vert=True, pgrid_ref='auto'):
         RT = False
         if "core_benchmark" in dir(input):
             # need to switch to 'radiative_tranfer' flag
@@ -341,224 +347,144 @@ class rg_out:
             if input.chemistry == 1:
                 chem = 1
 
+        #some basic info
+        self.ntsi = ntsi
+        self.nts = nts
         # Read model results
         for t in np.arange(ntsi - 1, nts):
             if pressure_vert == True:
-                fileh5 = resultsf + '/regrid_' + simID + '_' + np.str(t + 1)
+                if pgrid_ref == 'auto':
+                    pgrid_folder = resultsf + '/pgrid_%d_%d_1'%(ntsi,nts)
+                else:
+                    pgrid_folder = resultsf + '/' + pgrid_ref[:-4]
+                fileh5 = pgrid_folder + '/regrid_' + simID + '_' + np.str(t + 1)
             else:
                 fileh5 = resultsf + '/regrid_height_' + simID + '_' + np.str(t + 1)
             fileh5 += '.h5'
             if os.path.exists(fileh5):
-                openh5 = h5py.File(fileh5)
+                openh5 = h5py.File(fileh5,'r+')
             else:
                 print(fileh5 + ' not found, regridding now with default settings...')
                 regrid(resultsf, simID, ntsi, nts, pgrid_ref=pgrid_ref)
-                openh5 = h5py.File(fileh5)
+                openh5 = h5py.File(fileh5,'r+')
 
-            Rhoi = openh5['Rho'][...]
-            Tempi = openh5['Temperature'][...]
-            Ui = openh5['U'][...]
-            Vi = openh5['V'][...]
-            Wi = openh5['W'][...]
-            if pressure_vert == True:
-                Prei = openh5['Pressure'][...]
-            else:
-                Alti = openh5['Altitude'][...]
-                Prei = np.zeros_like(Alti)
-            lati = openh5['Latitude'][...]
-            loni = openh5['Longitude'][...]
+            for key in openh5.keys():
+                if t == ntsi - 1:  #set up VDS layout shape
+                    if openh5[key].ndim == 1:
+                        setattr(self,key,openh5[key][:])
+                    else:
+                        vars()[key+'_lo'] = h5py.VirtualLayout(shape=
+                                            np.shape(openh5[key])+(nts-ntsi+1,),dtype='f8')
+                if key+'_lo' in vars():
+                    if openh5[key].ndim == 2:
+                        vars()[key+'_lo'][:,:,t-ntsi+1] = h5py.VirtualSource(openh5[key])
+                    elif openh5[key].ndim == 3:
+                        vars()[key+'_lo'][:,:,:,t-ntsi+1] = h5py.VirtualSource(openh5[key])
+                    else:
+                        raise IOError('Property %s with unknown dimensions in regrid file'%key)
 
-            if RT:
-                tau_swi = openh5['tau_sw'][...]
-                tau_lwi = openh5['tau_lw'][...]
-                if 'fnet_up' in openh5.keys():
-                    flw_upi = openh5['fnet_up'][...]
-                    flw_dni = openh5['fnet_dn'][...]
+        fileVDS = resultsf+'/regrid_'+simID+'_'+str(ntsi)+'_'+str(nts)+'_VDS.h5'
+        self.openVDS = h5py.File(fileVDS,'w',libver='latest')
+
+        for key in openh5.keys():
+            if key+'_lo' in vars():
+                setattr(self,key,self.openVDS.create_virtual_dataset(key,vars()[key+'_lo'],fillvalue=0))
+
+    def closeVDS(self):
+        self.openVDS.close()
+
+    def load(self,keys):
+        tlen = self.nts-self.ntsi+1
+        for key in keys:
+            if key in self.openVDS.keys():
+                data_ref = getattr(self, key)
+                if isinstance(data_ref,h5py.Dataset):
+                    if data_ref.size*8 > psutil.virtual_memory().available:
+                        raise IOError("Dataset %s too large for memory; not loading"%key)
+                    data = data_ref[...]
+                    setattr(self,key,data)
                 else:
-                    flw_upi = openh5['flw_up'][...]
-                    flw_dni = openh5['flw_dn'][...]
-                insoli = openh5['insol'][...]
-                if 'Tsurface' in openh5.keys():
-                    Tsurfi = openh5['Tsurface'][...]
-                else:
-                    surf = 0
-            if input.TSRT:
-                mustar_i = openh5['mustar'][...]
-                f_up_tot_i = openh5['f_up_tot'][...]
-                f_down_tot_i = openh5['f_down_tot'][...]
-                f_net_i = openh5['f_net'][...]
-                q_heat_i = openh5['q_heat'][...]
-
-            if chem == 1:
-                ch4i = openh5['ch4'][...]
-                coi = openh5['co'][...]
-                h2oi = openh5['h2o'][...]
-                co2i = openh5['co2'][...]
-                nh3i = openh5['nh3'][...]
-
-            PVi = openh5['PV'][...]
-            if 'RV' in openh5.keys():
-                RVi = openh5['RV'][...][0]
+                    print("Dataset %s has already been loaded into memory"%key)
             else:
-                RVi = openh5['RVw'][...]
+                print("Invalid data set specified: %s; not loading"%key)
 
-            if 'Etotal' in openh5.keys():
-                Etotali = openh5['Etotal'][...]
-                Entropyi = openh5['Entropy'][...]
-                AngMomzi = openh5['AngMomz'][...]
+    def load_all(self):
+        keys = self.openVDS.keys()
+        self.load(keys)
+        self.closeVDS()
 
-            openh5.close()
-
-            if t == ntsi - 1:
-                self.Rho = np.zeros(np.shape(Rhoi) + (nts - ntsi + 1,))
-                self.U = np.zeros(np.shape(Ui) + (nts - ntsi + 1,))
-                self.V = np.zeros(np.shape(Vi) + (nts - ntsi + 1,))
-                self.W = np.zeros(np.shape(Wi) + (nts - ntsi + 1,))
-                self.Temperature = np.zeros(np.shape(Tempi) + (nts - ntsi + 1,))
-                if pressure_vert == True:
-                    self.Pressure = np.zeros(np.shape(Prei) + (nts - ntsi + 1,))
-                else:
-                    self.Altitude = np.zeros(np.shape(Alti) + (nts - ntsi + 1,))
-                self.lat = np.zeros(np.shape(lati) + (nts - ntsi + 1,))
-                self.lon = np.zeros(np.shape(loni) + (nts - ntsi + 1,))
-                self.PV = np.zeros(np.shape(PVi) + (nts - ntsi + 1,))
-                self.RV = np.zeros(np.shape(RVi) + (nts - ntsi + 1,))
-
-                if RT:
-                    self.tau_sw = np.zeros(np.shape(tau_swi) + (nts - ntsi + 1,))
-                    self.tau_lw = np.zeros(np.shape(tau_lwi) + (nts - ntsi + 1,))
-                    self.flw_up = np.zeros(np.shape(flw_upi) + (nts - ntsi + 1,))
-                    self.flw_dn = np.zeros(np.shape(flw_dni) + (nts - ntsi + 1,))
-                    self.insol = np.zeros(np.shape(insoli) + (nts - ntsi + 1,))
-                    if surf:
-                        self.Tsurface = np.zeros(np.shape(Tsurfi) + (nts - ntsi + 1,))
-                if input.TSRT:
-                    self.mustar = np.zeros(np.shape(mustar_i) + (nts - ntsi + 1,))
-                    self.f_up_tot = np.zeros(np.shape(f_up_tot_i) + (nts - ntsi + 1,))
-                    self.f_down_tot = np.zeros(np.shape(f_down_tot_i) + (nts - ntsi + 1,))
-                    self.f_net = np.zeros(np.shape(f_net_i) + (nts - ntsi + 1,))
-                    self.q_heat = np.zeros(np.shape(q_heat_i) + (nts - ntsi + 1,))
-                if chem == 1:
-                    self.ch4 = np.zeros(np.shape(ch4i) + (nts - ntsi + 1,))
-                    self.co = np.zeros(np.shape(coi) + (nts - ntsi + 1,))
-                    self.h2o = np.zeros(np.shape(h2oi) + (nts - ntsi + 1,))
-                    self.co2 = np.zeros(np.shape(co2i) + (nts - ntsi + 1,))
-                    self.nh3 = np.zeros(np.shape(nh3i) + (nts - ntsi + 1,))
-                if 'Etotali' in locals():
-                    self.Etotal = np.zeros(np.shape(Etotali) + (nts - ntsi + 1,))
-                    self.Entropy = np.zeros(np.shape(Entropyi) + (nts - ntsi + 1,))
-                    self.AngMomz = np.zeros(np.shape(AngMomzi) + (nts - ntsi + 1,))
-
-            self.Rho[:, :, :, t - ntsi + 1] = Rhoi
-            self.U[:, :, :, t - ntsi + 1] = Ui
-            self.V[:, :, :, t - ntsi + 1] = Vi
-            self.W[:, :, :, t - ntsi + 1] = Wi
-            self.Temperature[:, :, :, t - ntsi + 1] = Tempi
-            if pressure_vert == True:
-                self.Pressure[:, t - ntsi + 1] = Prei
-                if t > ntsi - 1:
-                    if (Prei == self.Pressure[:, 0]).all() == False:
-                        print('Warning: Pressure grid in file %d does not match file %d' % (t, ntsi))
-            else:
-                self.Altitude[:, t - ntsi + 1] = Alti
-            self.lat[:, t - ntsi + 1] = lati
-            self.lon[:, t - ntsi + 1] = loni
-            self.PV[:, :, :, t - ntsi + 1] = PVi
-            self.RV[:, :, :, t - ntsi + 1] = RVi
-
-            if RT:
-                self.tau_sw[:, :, :, t - ntsi + 1] = tau_swi
-                self.tau_lw[:, :, :, t - ntsi + 1] = tau_lwi
-                self.flw_up[:, :, :, t - ntsi + 1] = flw_upi
-                self.flw_dn[:, :, :, t - ntsi + 1] = flw_dni
-                self.insol[:, :, t - ntsi + 1] = insoli
-                if surf:
-                    self.Tsurface[:, :, t - ntsi + 1] = Tsurfi
-            if input.TSRT:
-                self.mustar[:, :, t - ntsi + 1] = mustar_i
-                self.f_up_tot[:, :, :, t - ntsi + 1] = f_up_tot_i
-                self.f_down_tot[:, :, :, t - ntsi + 1] = f_down_tot_i
-                self.f_net[:, :, :, t - ntsi + 1] = f_net_i
-                self.q_heat[:, :, :, t - ntsi + 1] = q_heat_i
-            if chem == 1:
-                self.ch4[:, :, :, t - ntsi + 1] = ch4i
-                self.co[:, :, :, t - ntsi + 1] = coi
-                self.h2o[:, :, :, t - ntsi + 1] = h2oi
-                self.co2[:, :, :, t - ntsi + 1] = co2i
-                self.nh3[:, :, :, t - ntsi + 1] = nh3i
-            if 'Etotali' in locals():
-                self.Etotal[:, :, :, t - ntsi + 1] = Etotali
-                self.Entropy[:, :, :, t - ntsi + 1] = Entropyi
-                self.AngMomz[:, :, :, t - ntsi + 1] = AngMomzi
 
 class GetOutput:
     def __init__(self, resultsf, simID, ntsi, nts, stride=1, openrg=0, pressure_vert=True, rotation=False, theta_y=0, theta_z=0, pgrid_ref='auto'):
-        self.input = input(resultsf, simID)
-        self.grid = grid(resultsf, simID, rotation=rotation, theta_y=theta_y, theta_z=theta_z)
-        self.output = output(resultsf, simID, ntsi, nts, self.input, self.grid, stride=stride)
-        if openrg == 1:
-            self.rg = rg_out(resultsf, simID, ntsi, nts, self.input, self.output, self.grid,
+        self.input = input_new(resultsf, simID)
+        self.grid = grid_new(resultsf, simID, rotation=rotation, theta_y=theta_y, theta_z=theta_z)
+        if openrg == 1:  #checking for regrid before output prevents file open conflict
+            self.rg = rg_out_new(resultsf, simID, ntsi, nts, self.input, self.grid,
                              pressure_vert=pressure_vert, pgrid_ref=pgrid_ref)
-
+        self.output = output_new(resultsf, simID, ntsi, nts, self.input, self.grid, stride=stride)
 
 def define_Pgrid(resultsf, simID, ntsi, nts, stride, overwrite=False):
-    # first we need the grid size
-    fileh5 = resultsf + '/esp_output_grid_' + simID + '.h5'
-    if os.path.exists(fileh5):
-        openh5 = h5py.File(fileh5)
-    else:
-        raise IOError(fileh5 + ' not found!')
-    nv = np.int(openh5['nv'][0])
-    point_num = np.int(openh5['point_num'][0])
-    Altitude = openh5['Altitude'][...]
-    Altitudeh = openh5['Altitudeh'][...]
-    openh5.close()
-
-    # we also need to know if we included a surface
-    fileh5 = resultsf + '/esp_output_planet_' + simID + '.h5'
-    if os.path.exists(fileh5):
-        openh5 = h5py.File(fileh5)
-    else:
-        raise IOError(fileh5 + ' not found!')
-    if openh5['core_benchmark'][0] > 0:
-        surf = 0
-    else:
-        if "radiative_transfer" in openh5:
-            surf = openh5['surface'][0]
-        else:
-            surf = 0
-
-    openh5.close()
-
-    # now we'll loop over all the files to get the pressure_mean
-    num_out = np.int((nts - ntsi) / stride) + 1
-    pressure_mean = np.zeros((point_num, nv, num_out))
-    for i in np.arange(num_out):
-        t = ntsi + stride * i
-        fileh5 = resultsf + '/esp_output_' + simID + '_' + np.str(t) + '.h5'
-        if os.path.exists(fileh5):
-            openh5 = h5py.File(fileh5)
-        else:
-            raise IOError(fileh5 + ' not found!')
-
-        pressure_mean[:, :, i] = np.reshape(openh5['Pressure_mean'][...], (point_num, nv))
-        openh5.close()
-
-    pgrid = np.mean(np.mean(pressure_mean, axis=0), axis=1)
-    if surf == 1:
-        extrap_low = (Altitudeh[0] - Altitude[1]) / (Altitude[0] - Altitude[1])
-        Psurf = pressure_mean[:, 1, :] + extrap_low * (pressure_mean[:, 0, :] - pressure_mean[:, 1, :])
-        Psurf_mean = np.mean(np.mean(Psurf, axis=0), axis=0)
-        pgrid = np.concatenate((np.array([Psurf_mean]), pgrid))
-
     pfile = 'pgrid_%d_%d_%d.txt' % (ntsi, nts, stride)
     if not os.path.exists(resultsf + '/' + pfile) or overwrite == True:
+        #check for existence of pgrid file
+
+        # first we need the grid size
+        fileh5 = resultsf + '/esp_output_grid_' + simID + '.h5'
+        if os.path.exists(fileh5):
+            openh5 = h5py.File(fileh5,'r')
+        else:
+            raise IOError(fileh5 + ' not found!')
+        nv = np.int(openh5['nv'][0])
+        point_num = np.int(openh5['point_num'][0])
+        Altitude = openh5['Altitude'][...]
+        Altitudeh = openh5['Altitudeh'][...]
+        openh5.close()
+
+        # we also need to know if we included a surface
+        fileh5 = resultsf + '/esp_output_planet_' + simID + '.h5'
+        if os.path.exists(fileh5):
+            openh5 = h5py.File(fileh5,'r')
+        else:
+            raise IOError(fileh5 + ' not found!')
+        if openh5['core_benchmark'][0] > 0:
+            surf = 0
+        else:
+            if "radiative_transfer" in openh5:
+                surf = openh5['surface'][0]
+            else:
+                surf = 0
+
+        openh5.close()
+
+        # now we'll loop over all the files to get the pressure_mean
+        num_out = np.int((nts - ntsi) / stride) + 1
+        pressure_mean = np.zeros((point_num, nv, num_out))
+        for i in np.arange(num_out):
+            t = ntsi + stride * i
+            fileh5 = resultsf + '/esp_output_' + simID + '_' + np.str(t) + '.h5'
+            if os.path.exists(fileh5):
+                openh5 = h5py.File(fileh5,'r')
+            else:
+                raise IOError(fileh5 + ' not found!')
+
+            pressure_mean[:, :, i] = np.reshape(openh5['Pressure_mean'][...], (point_num, nv))
+            openh5.close()
+
+        pgrid = np.mean(np.mean(pressure_mean, axis=0), axis=1)
+        if surf == 1:
+            extrap_low = (Altitudeh[0] - Altitude[1]) / (Altitude[0] - Altitude[1])
+            Psurf = pressure_mean[:, 1, :] + extrap_low * (pressure_mean[:, 0, :] - pressure_mean[:, 1, :])
+            Psurf_mean = np.mean(np.mean(Psurf, axis=0), axis=0)
+            pgrid = np.concatenate((np.array([Psurf_mean]), pgrid))
+
         f = open(resultsf + '/' + pfile, 'w')
         for j in np.arange(len(pgrid)):
             f.write('%d %#.6e\n' % (j, pgrid[j]))
         f.close()
     else:
-        raise IOError(pfile + ' already exists in this directory!')
+        print(pfile + ' already exists in this directory! Skipping...')
+        #raise IOError(pfile + ' already exists in this directory!')
+    return pfile
 
 
 if has_pycuda:
@@ -706,8 +632,8 @@ if has_pycuda:
     """)
 
 
-def create_rg_map(resultsf, simID, rotation=False, theta_z=0, theta_y=0):
-    outall = GetOutput(resultsf, simID, 0, 0, rotation=rotation, theta_z=theta_z, theta_y=theta_y)
+def create_rg_map(resultsf, simID, idx1, idx2, rotation=False, theta_z=0, theta_y=0):
+    outall = GetOutput(resultsf, simID, idx1, idx2, rotation=rotation, theta_z=theta_z, theta_y=theta_y)
     input = outall.input
     grid = outall.grid
 
@@ -793,7 +719,7 @@ def regrid(resultsf, simID, ntsi, nts, pgrid_ref='auto', overwrite=False, comp=4
 
     if not os.path.exists(resultsf + '/regrid_map.npz') or overwrite:
         # if numpy zip file containing weights d.n.e., then create it
-        create_rg_map(resultsf, simID, rotation=rotation, theta_z=theta_z, theta_y=theta_y)
+        create_rg_map(resultsf, simID, ntsi, ntsi, rotation=rotation, theta_z=theta_z, theta_y=theta_y)
 
     # open numpy zip file containing weights
     rg_map = np.load(resultsf + '/regrid_map.npz')
@@ -807,26 +733,32 @@ def regrid(resultsf, simID, ntsi, nts, pgrid_ref='auto', overwrite=False, comp=4
     input = outall.input
     grid = outall.grid
     output = outall.output
+    output.load_reshape_all(grid)
 
     print('Regrid data in folder ' + resultsf + '...\n')
 
     # handling of vertical coordinate
     if pgrid_ref == 'auto':
-        try:
-            files_found = spr.check_output('ls ' + resultsf + '/pgrid_*.txt', shell=True).split()
-        except:
-            raise IOError('No pgrid file found in "%s/", please run "pgrid -i <first> -l <last> %s"' % (resultsf, resultsf))
-        if len(files_found) > 1:
-            raise IOError('Multiple pgrid files found in "%s/", please specify with -pgrid flag' % resultsf)
-        else:
-            pgrid_file = files_found[0].decode()
+        pgrid_file = resultsf+'/'+define_Pgrid(resultsf,simID,ntsi,nts,1,overwrite=overwrite)
+        # try:
+        #     files_found = spr.check_output('ls ' + resultsf + '/pgrid_*.txt', shell=True).split()
+        # except:
+        #     raise IOError('No pgrid file found in "%s/", please run "pgrid -i <first> -l <last> %s"' % (resultsf, resultsf))
+        # if len(files_found) > 1:
+        #     raise IOError('Multiple pgrid files found in "%s/", please specify with -pgrid flag' % resultsf)
+        # else:
+        #     pgrid_file = files_found[0].decode()
     else:
         if os.path.exists(resultsf + '/' + pgrid_ref):
             pgrid_file = resultsf + '/' + pgrid_ref
         else:
             raise IOError('pgrid file %s not found!' % (resultsf + '/' + pgrid_ref))
+    pgrid_folder = pgrid_file[:-4]  #define folder as pgrid without file suffix
     print('Vertical coordinate = pressure from file %s' % pgrid_file)
     Pref = np.loadtxt(pgrid_file, unpack=True, usecols=1)
+    p_output_path = pathlib.Path(pgrid_folder)
+    if not p_output_path.exists():
+        p_output_path.mkdir()
 
     # destination grid and set some dimensions
     loni, lati = np.meshgrid(lon_range, lat_range)
@@ -862,7 +794,8 @@ def regrid(resultsf, simID, ntsi, nts, pgrid_ref='auto', overwrite=False, comp=4
     for t in np.arange(ntsi, nts + 1):
         # check for existing h5 files
         proceed = 0
-        fileh5p = resultsf + '/regrid_' + simID + '_' + np.str(t)
+        skip_height_file = 0
+        fileh5p = pgrid_folder + '/regrid_' + simID + '_' + np.str(t)
 
         fileh5h = resultsf + '/regrid_height_' + simID + '_' + np.str(t)
         if rotation == True:  # tell the user they asked for a rotated grid
@@ -870,13 +803,19 @@ def regrid(resultsf, simID, ntsi, nts, pgrid_ref='auto', overwrite=False, comp=4
                   % (theta_z * 180 / np.pi, theta_y * 180 / np.pi))
         fileh5p += '.h5'
         fileh5h += '.h5'
-        if os.path.exists(fileh5p) or os.path.exists(fileh5h):  # regrid files exist
+        if os.path.exists(fileh5p) and os.path.exists(fileh5h):  # regrid files exist
             if overwrite == True:  # overwrite existing files
                 proceed = 1
             else:  # skip existing files
-                print(fileh5p + 'or ' + fileh5h + ' already present! Skipping time = %d' % t)
-        else:  # no existing regrid files, all clear
+                print(fileh5p + ' and ' + fileh5h + ' already present! Skipping time = %d' % t)
+        else:  # >= one file missing
             proceed = 1
+            if os.path.exists(fileh5h):  #height file already exists
+                if overwrite == True:
+                    skip_height_file = 0
+                else:
+                    print(fileh5h + ' already present! Skipping height file for time = %d' % t)
+                    skip_height_file = 1
 
         # begin regridding
         if proceed == 1:
@@ -885,6 +824,7 @@ def regrid(resultsf, simID, ntsi, nts, pgrid_ref='auto', overwrite=False, comp=4
             # read in one file at a time to prevent mem overflow
             outall = GetOutput(resultsf, simID, t, t, rotation=rotation, theta_z=theta_z, theta_y=theta_y)
             output = outall.output
+            output.load_reshape_all(grid)
 
             # interpolate in z to middle of layers using this
             interpz = (grid.Altitude - grid.Altitudeh[:-1]) / (grid.Altitudeh[1:] - grid.Altitudeh[:-1])
@@ -896,13 +836,25 @@ def regrid(resultsf, simID, ntsi, nts, pgrid_ref='auto', overwrite=False, comp=4
                       'Mh': output.Mh[:, :, :, 0],
                       'Pressure': output.Pressure[:, :, 0],
                       'Rd': output.Rd[:, :, 0],
-                      'Cp': output.Cp[:, :, 0]}
+                      'Cp': output.Cp[:, :, 0],
+                      'Temperature_mean': (output.Pressure_mean/(output.Rd*output.Rho_mean))[:,:,0],
+                      'W_mean': (output.Wh_mean[:, :-1, 0] + (output.Wh_mean[:, 1:, 0]-output.Wh_mean[:, :-1, 0])*interpz[None, :])/output.Rho_mean[:, :, 0],
+                      'Rho_mean': output.Rho_mean[:, :, 0],
+                      'Mh_mean': output.Mh_mean[:, :, :, 0],
+                      'Pressure_mean': output.Pressure_mean[:, :, 0]}
+
+            if input.RT or input.TSRT:
+                source['qheat'] = output.qheat[:, :, 0]
 
             if input.RT == 1:
                 source['flw_up'] = output.flw_up[:, :-1, 0] + (output.flw_up[:, 1:, 0] - output.flw_up[:, :-1, 0]) * interpz[None, :]
                 source['flw_dn'] = output.flw_dn[:, :-1, 0] + (output.flw_dn[:, 1:, 0] - output.flw_dn[:, :-1, 0]) * interpz[None, :]
+                source['fsw_dn'] = output.fsw_dn[:, :-1, 0] + (output.fsw_dn[:, 1:, 0] - output.fsw_dn[:, :-1, 0]) * interpz[None, :]
+                fnet_tmp = output.flw_up[:,:,0] - (output.flw_dn[:,:,0]+output.fsw_dn[:,:,0])
+                source['DGf_net'] = fnet_tmp[:,:-1] + (fnet_tmp[:, 1:] - fnet_tmp[:, :-1]) * interpz[None, :]
                 source['tau_sw'] = output.tau_sw[:, :, 0]
                 source['tau_lw'] = output.tau_lw[:, :, 0]
+                source['DGqheat'] = output.DGqheat[:, :, 0]
                 source['insol'] = output.Insol[:, 0]
                 if surf == 1:
                     source['Tsurface'] = output.Tsurface[:, 0]
@@ -915,28 +867,33 @@ def regrid(resultsf, simID, ntsi, nts, pgrid_ref='auto', overwrite=False, comp=4
 
             if input.TSRT:
                 source['mustar'] = output.mustar[:, 0]
-                source['f_net'] = output.f_net[:, :-1, 0] + (output.f_net[:, 1:, 0] - output.f_net[:, :-1, 0]) * interpz[None, :]
-                source['q_heat'] = output.q_heat[:, :, 0]
+                source['TSf_net'] = output.f_net[:, :-1, 0] + (output.f_net[:, 1:, 0] - output.f_net[:, :-1, 0]) * interpz[None, :]
+                source['TSqheat'] = output.TSqheat[:, :, 0]
                 source['f_up_tot'] = output.f_up_tot[:, :-1, 0] + (output.f_up_tot[:, 1:, 0] - output.f_up_tot[:, :-1, 0]) * interpz[None, :]
                 source['f_down_tot'] = output.f_down_tot[:, :-1, 0] + (output.f_down_tot[:, 1:, 0] - output.f_down_tot[:, :-1, 0]) * interpz[None, :]
             if chem == 1:
-                source['ch4'] = output.ch4[:, :, 0]
-                source['co'] = output.co[:, :, 0]
-                source['h2o'] = output.h2o[:, :, 0]
-                source['co2'] = output.co2[:, :, 0]
-                source['nh3'] = output.nh3[:, :, 0]
+                source['ch4'] = output.ch4[:, :, 0] / output.Rho[:,:,0]
+                source['co'] = output.co[:, :, 0]/ output.Rho[:,:,0]
+                source['h2o'] = output.h2o[:, :, 0]/ output.Rho[:,:,0]
+                source['co2'] = output.co2[:, :, 0]/ output.Rho[:,:,0]
+                source['nh3'] = output.nh3[:, :, 0]/ output.Rho[:,:,0]
 
             # calculate zonal and meridional velocity (special step for Mh)
-            source['U'] = (-source['Mh'][0] * np.sin(grid.lon[:, None]) +
-                           source['Mh'][1] * np.cos(grid.lon[:, None])) / source['Rho']
-            source['V'] = (-source['Mh'][0] * np.sin(grid.lat[:, None]) * np.cos(grid.lon[:, None])
-                           - source['Mh'][1] * np.sin(grid.lat[:, None]) * np.sin(grid.lon[:, None])
-                           + source['Mh'][2] * np.cos(grid.lat[:, None])) / source['Rho']
+            source['U'] = (-source['Mh'][0]*np.sin(grid.lon[:,None])+\
+                           source['Mh'][1]*np.cos(grid.lon[:, None]))/source['Rho']
+            source['V'] = (-source['Mh'][0]*np.sin(grid.lat[:,None])*np.cos(grid.lon[:,None])\
+                      -source['Mh'][1]*np.sin(grid.lat[:,None])*np.sin(grid.lon[:,None])\
+                           + source['Mh'][2]*np.cos(grid.lat[:, None]))/source['Rho']
+            source['U_mean'] = (-source['Mh_mean'][0]*np.sin(grid.lon[:,None])+\
+                           source['Mh_mean'][1]*np.cos(grid.lon[:, None]))/source['Rho_mean']
+            source['V_mean'] = (-source['Mh_mean'][0]*np.sin(grid.lat[:,None])*np.cos(grid.lon[:,None])\
+                      -source['Mh_mean'][1]*np.sin(grid.lat[:,None])*np.sin(grid.lon[:,None])\
+                           + source['Mh_mean'][2]*np.cos(grid.lat[:, None]))/source['Rho_mean']
 
             # set up intermediate arrays (icogrid and pressure)
             interm = {}
             for key in source.keys():
-                if key == 'Mh':
+                if key == 'Mh' or key == 'Mh_mean':
                     pass
                 elif np.shape(source[key]) == (grid.point_num,):
                     # 2D field (e.g., insolation) -> not needed
@@ -974,7 +931,7 @@ def regrid(resultsf, simID, ntsi, nts, pgrid_ref='auto', overwrite=False, comp=4
             # set up destination arrays (lat-lon and pressure/height)
             dest = {}
             for key in interm.keys():
-                if key == 'Mh' or key == 'Pressure':
+                if key == 'Mh' or key == 'Mh_mean' or key == 'Pressure':
                     pass  # don't need these any further
                 elif np.shape(interm[key]) == (d_lon[0], d_lon[1]):
                     # 2D field (e.g., insolation)
@@ -1015,19 +972,20 @@ def regrid(resultsf, simID, ntsi, nts, pgrid_ref='auto', overwrite=False, comp=4
             openh5.close()
 
             # create h5 files (height grid)
-            openh5 = h5py.File(fileh5h, "w")
-            print('Writing file ' + fileh5h + '...')
-            Alt = openh5.create_dataset("Altitude", data=grid.Altitude,
-                                        compression='gzip', compression_opts=comp)
-            Lat = openh5.create_dataset("Latitude", data=lat_range * 180 / np.pi,
-                                        compression='gzip', compression_opts=comp)
-            Lon = openh5.create_dataset("Longitude", data=lon_range * 180 / np.pi,
-                                        compression='gzip', compression_opts=comp)
-            # data
-            for key in dest.keys():
-                tmp_data = openh5.create_dataset(key, data=interm[key],
-                                                 compression='gzip', compression_opts=comp)
-            openh5.close()
+            if not skip_height_file:
+                openh5 = h5py.File(fileh5h, "w")
+                print('Writing file ' + fileh5h + '...')
+                Alt = openh5.create_dataset("Altitude", data=grid.Altitude,
+                                            compression='gzip', compression_opts=comp)
+                Lat = openh5.create_dataset("Latitude", data=lat_range * 180 / np.pi,
+                                            compression='gzip', compression_opts=comp)
+                Lon = openh5.create_dataset("Longitude", data=lon_range * 180 / np.pi,
+                                            compression='gzip', compression_opts=comp)
+                # data
+                for key in dest.keys():
+                    tmp_data = openh5.create_dataset(key, data=interm[key],
+                                                     compression='gzip', compression_opts=comp)
+                openh5.close()
 
 
 def KE_spect(input, grid, output, sigmaref, coord='icoh', lmax_adjust=0):
@@ -1128,7 +1086,7 @@ def maketable(x, y, z, xname, yname, zname, resultsf, fname):
     f.close()
 
 
-def vertical_lat(input, grid, output, rg, sigmaref, z, slice=[0, 360], save=True, axis=False, csp=500, wind_vectors=False, use_p=True, clevs=[40]):
+def vertical_lat(input, grid, output, rg, sigmaref, z, slice=['default'], save=True, axis=None, csp=500, wind_vectors=False, use_p=True, clevs=[40]):
     # generic pressure/latitude plot function
 
     # Set the reference pressure
@@ -1141,6 +1099,10 @@ def vertical_lat(input, grid, output, rg, sigmaref, z, slice=[0, 360], save=True
 
     if not isinstance(slice, list):
         raise IOError("'slice' argument must be a list")
+    if slice[0] == 'default':
+        slice = [0, 360]
+    else:
+        slice = [np.float(slice[0]),np.float(slice[1])]
 
     lat = z['lat']
     lon = z['lon']
@@ -1162,7 +1124,7 @@ def vertical_lat(input, grid, output, rg, sigmaref, z, slice=[0, 360], save=True
         ##################
         # Averaging in time and longitude
         if tsp > 1:
-            Zonall = np.nanmean(z['value'][:, mask_ind[:, 0], :, :], axis=1)
+            Zonall = np.nanmean(z['value'][:, mask_ind[:], :, :], axis=1)
             # Vl = np.nanmean(rg.V[:,:,:,:],axis=1)
             # Wl = np.nanmean(rg.W[:,:,:,:],axis=1)
             Zonallt = np.nanmean(Zonall[:, :, :], axis=2)
@@ -1170,25 +1132,25 @@ def vertical_lat(input, grid, output, rg, sigmaref, z, slice=[0, 360], save=True
             # Wlt = np.nanmean(Wl[:,:,:],axis=2)
             del Zonall
             if wind_vectors == True:
-                Vl = np.nanmean(rg.V[:, mask_ind[:, 0], :, :], axis=1)
-                Wl = np.nanmean(rg.W[:, mask_ind[:, 0], :, :], axis=1)
+                Vl = np.nanmean(rg.V[:, mask_ind[:], :, :], axis=1)
+                Wl = np.nanmean(rg.W[:, mask_ind[:], :, :], axis=1)
                 Vlt = np.nanmean(Vl[:, :, :], axis=2)
                 Wlt = np.nanmean(Wl[:, :, :], axis=2)
                 del Vl, Wl
         else:
-            Zonallt = np.nanmean(z['value'][:, :, :, 0][:, mask_ind[:, 0], :], axis=1)
+            Zonallt = np.nanmean(z['value'][:, :, :, 0][:, mask_ind[:], :], axis=1)
             # Vlt = np.nanmean(rg.V[:,:,:,0],axis=1)
             # Wlt = np.nanmean(rg.W[:,:,:,0],axis=1)
             if wind_vectors == True:
-                Vlt = np.nanmean(rg.V[:, :, :, 0][:, mask_ind[:, 0], :], axis=1)
-                Wlt = np.nanmean(rg.W[:, :, :, 0][:, mask_ind[:, 0], :], axis=1)
+                Vlt = np.nanmean(rg.V[:, :, :, 0][:, mask_ind[:], :], axis=1)
+                Wlt = np.nanmean(rg.W[:, :, :, 0][:, mask_ind[:], :], axis=1)
 
     elif len(slice) == 1:
         if slice[0] in lon:
-            Zonall = z['value'][:, lon[:, 0] == slice[0], :, :]
+            Zonall = z['value'][:, lon[:] == slice[0], :, :]
             if wind_vectors == True:
-                Vl = rg.V[:, lon[:, 0] == slice[0], :, :]
-                Wl = rg.W[:, lon[:, 0] == slice[0], :, :]
+                Vl = rg.V[:, lon[:] == slice[0], :, :]
+                Wl = rg.W[:, lon[:] == slice[0], :, :]
         else:
             Zonall = np.zeros((len(lat), 1, d_sig, tsp))
             if wind_vectors == True:
@@ -1223,60 +1185,76 @@ def vertical_lat(input, grid, output, rg, sigmaref, z, slice=[0, 360], save=True
     # Create figure #
     #################
     # Latitude
-    latp = lat[:, 0] * np.pi / 180
+    latp = lat[:] * np.pi / 180
 
     if use_p:
         # need to set desired pressure range (major PITA!)
         # prange = np.where(np.logical_and(rg.Pressure[:,0]>=np.min(Pref),rg.Pressure[:,0]<=np.max(Pref)))
-        prange = np.where(rg.Pressure[:, 0] >= np.min(Pref))
-        ycoord = rg.Pressure[prange[0], 0] / 1e5
+        prange = np.where(rg.Pressure[:] >= np.min(Pref))
+        ycoord = rg.Pressure[prange[0]] / 1e5
         zvals = Zonallt[:, prange[0]].T
     else:
-        hrange = np.where(np.logical_and(rg.Altitude[:, 0] >= np.min(sigmaref), rg.Altitude[:, 0] <= np.max(sigmaref)))
-        ycoord = rg.Altitude[hrange[0], 0] / 1000
+        hrange = np.where(np.logical_and(rg.Altitude[:] >= np.min(sigmaref), rg.Altitude[:] <= np.max(sigmaref)))
+        ycoord = rg.Altitude[hrange[0]] / 1000
         zvals = Zonallt[:, hrange[0]].T
 
     # Contour plot
     if len(clevs) == 1:
         clevels = np.int(clevs[0])
     elif len(clevs) == 3:
-        clevels = np.linspace(np.int(clevs[0]), np.int(clevs[1]), np.int(clevs[2]))
+        if isinstance(clevs[2],str) and 'log' in clevs[2]:
+            clevels = np.logspace(np.log10(np.float(clevs[0])),np.log10(np.float(clevs[1])),np.int(clevs[2][:-3]))
+        else:
+            clevels = np.linspace(np.int(clevs[0]),np.int(clevs[1]),np.int(clevs[2]))
     else:
         raise IOError("clevs not valid!")
     # print(np.max(zvals))
+
     if isinstance(axis, axes.SubplotBase):
-        C = axis.contourf(latp * 180 / np.pi, ycoord, zvals, clevels, cmap=z['cmap'])
         ax = axis
-    elif axis == False:
-        plt.figure(figsize=(5, 4))
-        C = plt.contourf(latp * 180 / np.pi, ycoord, zvals, clevels, cmap=z['cmap'])
-        ax = plt.gca()
+        fig = plt.gcf()
+    elif (isinstance(axis, tuple)
+          and isinstance(axis[0], plt.Figure)
+          and isinstance(axis[1], axes.SubplotBase)):
+        fig = axis[0]
+        ax = axis[1]
+    elif axis is None:
+        fig, ax = plt.subplots(1, 1, figsize=(5, 4))
     else:
-        raise IOError("'axis = {}' but {} is not an axes.SubplotBase instance".format(axis, axis))
+        raise IOError("'axis = {}' but {} is neither an axes.SubplotBase instance nor a (axes.SubplotBase, plt.Figure) instance".format(axis, axis))
+
+    fig.set_tight_layout(True)
+
+    C = ax.contourf(latp * 180 / np.pi, ycoord, zvals, clevels, cmap=z['cmap'])
 
     if wind_vectors == True:
-        vspacing = np.int(np.shape(rg.lat)[0] / 10)
+        vspacing = np.int(np.shape(rg.Latitude)[0] / 10)
         if use_p:
             wspacing = np.int(np.shape(rg.Pressure)[0] / 10)
             Vlt = Vlt[:, prange[0]]
             Wlt = Wlt[:, prange[0]]
-            yqcoord = rg.Pressure[::wspacing, 0][prange[0]]
+            yqcoord = rg.Pressure[::wspacing][prange[0]]
         else:
             wspacing = np.int(np.shape(rg.Altitude)[0] / 10)
             Vlt = Vlt[:, hrange[0]]
             Wlt = Wlt[:, hrange[0]]
-            yqcoord = rg.Altitude[::wspacing, 0][hrange[0]]
+            yqcoord = rg.Altitude[::wspacing][hrange[0]]
 
         Vq = Vlt[::vspacing, ::wspacing].ravel()
         Wq = Wlt[::vspacing, ::wspacing].ravel()
         #preq = rg.Pressure[:,0][::spacing,::spacing].ravel()
         #latq = lati[::spacing,::spacing].ravel()
-        latq, preq = np.meshgrid(rg.lat[::vspacing, 0], yqcoord)
+        latq, preq = np.meshgrid(rg.Latitude[::vspacing], yqcoord)
         del Vlt, Wlt
-        plt.quiver(latq.ravel(), preq.ravel() / 1e5, Vq, Wq, color='0.5')
+        ax.quiver(latq.ravel(), preq.ravel() / 1e5, Vq, Wq, color='0.5')
 
-    clb = plt.colorbar(C, extend='both', ax=ax)
+    divider = make_axes_locatable(ax)
+    cax = divider.append_axes('right', size='5%', pad=0.05)
+    kwargs = {'format': '%#3.4e'}
+    #clb = plt.colorbar(C, extend='both', ax=ax)
+    clb = fig.colorbar(C, cax=cax, extend='both', **kwargs)
     clb.set_label(z['label'])
+
     if isinstance(csp, list) or isinstance(csp, tuple):
         levp = csp
     else:
@@ -1289,7 +1267,7 @@ def vertical_lat(input, grid, output, rg, sigmaref, z, slice=[0, 360], save=True
                 levp = np.arange(np.ceil(np.nanmin(Zonallt[:, hrange[0]]) / csp) * csp, np.floor(np.nanmax(Zonallt[:, hrange[0]]) / csp) * csp, csp)
 
     c2 = ax.contour(latp * 180 / np.pi, ycoord, zvals, levels=levp, colors='w', linewidths=1)
-    plt.clabel(c2, inline=False, fontsize=6, fmt='%d', use_clabeltext=True)
+    ax.clabel(c2, inline=False, fontsize=6, fmt='%d', use_clabeltext=True)
     for cc in C.collections:
         cc.set_edgecolor("face")  # fixes a stupid bug in matplotlib 2.0
     # ax.invert_yaxis()
@@ -1301,7 +1279,7 @@ def vertical_lat(input, grid, output, rg, sigmaref, z, slice=[0, 360], save=True
         ax.set_ylabel('Pressure (bar)')
         # ax.plot(latp*180/np.pi,np.zeros_like(latp)+np.max(output.Pressure[:,grid.nv-1,:])/1e5,'r--')
         #ax.set_ylim(np.max(rg.Pressure[prange[0], 0])/1e5, np.min(Pref)/1e5)
-        ax.set_ylim(np.max(rg.Pressure[prange[0], 0]) / 1e5, np.min(rg.Pressure[prange[0], 0]) / 1e5)
+        ax.set_ylim(np.max(rg.Pressure[prange[0]]) / 1e5, np.min(rg.Pressure[prange[0]]) / 1e5)
 
         if ax.get_ylim()[1] > ax.get_ylim()[0]:
             ax.invert_yaxis()
@@ -1313,40 +1291,43 @@ def vertical_lat(input, grid, output, rg, sigmaref, z, slice=[0, 360], save=True
     else:
         ax.set_title('Time = %#.3f-%#.3f days, Lon = (%#.3f,)' % (output.time[0], output.time[-1], slice[0]), fontsize=10)
 
-    if not os.path.exists(input.resultsf + '/figures'):
-        os.mkdir(input.resultsf + '/figures')
-    plt.tight_layout()
     if use_p:
         z['name'] += '_p'
     else:
         z['name'] += '_h'
-    pfile = False
+
+    pfile = None
     if save == True:
+        output_path = pathlib.Path(input.resultsf) / 'figures'
+        if not output_path.exists():
+            output_path.mkdir()
+
         # save the plot to file designated by z
         if len(slice) == 2:
             fname = '%s_ver_i%d_l%d_lon%#.2f-%#.2f' % (z['name'], output.ntsi, output.nts, slice[0], slice[1])
-            pfile = input.resultsf + '/figures/' + fname.replace(".", "+") + '.pdf'
         else:
             fname = '%s_ver_i%d_l%d_lon%#.2f' % (z['name'], output.ntsi, output.nts, slice[0])
-            pfile = input.resultsf + '/figures/' + fname.replace(".", "+") + '.pdf'
 
+        pfile = output_path / (fname.replace(".", "+") + '.pdf')
         plt.savefig(pfile)
 
         plt.close()
+        pfile = str(pfile)
+
     if z['mt'] == True:
         if len(slice) == 2:
             fname = '%s_ver_i%d_l%d_lon%#.2f-%#.2f.dat' % (z['name'], output.ntsi, output.nts, slice[0], slice[1])
         else:
             fname = '%s_ver_i%d_l%d_lon%#.2f.dat' % (z['name'], output.ntsi, output.nts, slice[0])
         if use_p:
-            maketable(latp * 180 / np.pi, rg.Pressure[prange[0], 0] / 1e5, Zonallt[:, prange[0]], 'Latitude(d)', 'Pressure(bar)', z['name'], input.resultsf, fname)
+            maketable(latp * 180 / np.pi, rg.Pressure[prange[0]] / 1e5, Zonallt[:, prange[0]], 'Latitude(d)', 'Pressure(bar)', z['name'], input.resultsf, fname)
         else:
-            maketable(latp * 180 / np.pi, rg.Altitude[hrange[0], 0], Zonallt[:, hrange[0]], 'Latitude(d)', 'Altitude(m)', z['name'], input.resultsf, fname)
+            maketable(latp * 180 / np.pi, rg.Altitude[hrange[0]], Zonallt[:, hrange[0]], 'Latitude(d)', 'Altitude(m)', z['name'], input.resultsf, fname)
 
     return pfile
 
 
-def vertical_lon(input, grid, output, rg, sigmaref, z, slice=[0, 360], save=True, axis=False, csp=500, wind_vectors=False, use_p=True, clevs=[40]):
+def vertical_lon(input, grid, output, rg, sigmaref, z, slice='default', save=True, axis=None, csp=500, wind_vectors=False, use_p=True, clevs=[40]):
     # generic pressure/longitude plot function
 
     # Set the reference pressure
@@ -1359,6 +1340,10 @@ def vertical_lon(input, grid, output, rg, sigmaref, z, slice=[0, 360], save=True
 
     if not isinstance(slice, list):
         raise IOError("'slice' argument must be a list")
+    if slice[0] == 'default':
+        slice = [-90, 90]
+    else:
+        slice = [np.float(slice[0]),np.float(slice[1])]
 
     lat = z['lat']
     lon = z['lon']
@@ -1382,7 +1367,7 @@ def vertical_lon(input, grid, output, rg, sigmaref, z, slice=[0, 360], save=True
 
         # Averaging in time and latitude (weighted by a cosine(lat))
         if tsp > 1:
-            Meridl = np.nanmean(z['value'][mask_ind[:, 0], :, :, :] * np.cos(lat[mask_ind[:, 0], 0] * np.pi / 180)[:, None, None, None], axis=0)
+            Meridl = np.nanmean(z['value'][mask_ind[:], :, :, :] * np.cos(lat[mask_ind[:]] * np.pi / 180)[:, None, None, None], axis=0)
             # Vl = np.nanmean(rg.V[:,:,:,:],axis=1)
             # Wl = np.nanmean(rg.W[:,:,:,:],axis=1)
             Meridlt = np.nanmean(Meridl[:, :, :], axis=2)
@@ -1390,25 +1375,25 @@ def vertical_lon(input, grid, output, rg, sigmaref, z, slice=[0, 360], save=True
             # Wlt = np.nanmean(Wl[:,:,:],axis=2)
             del Meridl
             if wind_vectors == True:
-                Ul = np.nanmean(rg.U[mask_ind[:, 0], :, :, :] * np.cos(lat[mask_ind[:, 0], 0] * np.pi / 180)[:, None, None, None], axis=0)
-                Wl = np.nanmean(rg.W[mask_ind[:, 0], :, :, :] * np.cos(lat[mask_ind[:, 0], 0] * np.pi / 180)[:, None, None, None], axis=0)
+                Ul = np.nanmean(rg.U[mask_ind[:], :, :, :] * np.cos(lat[mask_ind[:], 0] * np.pi / 180)[:, None, None, None], axis=0)
+                Wl = np.nanmean(rg.W[mask_ind[:], :, :, :] * np.cos(lat[mask_ind[:], 0] * np.pi / 180)[:, None, None, None], axis=0)
                 Ult = np.nanmean(Ul[:, :, :], axis=2)
                 Wlt = np.nanmean(Wl[:, :, :], axis=2)
                 del Ul, Wl
         else:
-            Meridlt = np.nanmean(z['value'][:, :, :, 0][mask_ind[:, 0], :, :] * np.cos(lat[mask_ind[:, 0], 0] * np.pi / 180)[:, None, None], axis=0)
+            Meridlt = np.nanmean(z['value'][:, :, :, 0][mask_ind[:], :, :] * np.cos(lat[mask_ind[:]] * np.pi / 180)[:, None, None], axis=0)
             # Ult = np.nanmean(rg.V[:,:,:,0],axis=1)
             # Wlt = np.nanmean(rg.W[:,:,:,0],axis=1)
             if wind_vectors == True:
-                Ult = np.nanmean(rg.U[:, :, :, 0][mask_ind[:, 0], :, :] * np.cos(lat[mask_ind[:, 0], 0] * np.pi / 180)[:, None, None], axis=0)
-                Wlt = np.nanmean(rg.W[:, :, :, 0][mask_ind[:, 0], :, :] * np.cos(lat[mask_ind[:, 0], 0] * np.pi / 180)[:, None, None], axis=0)
+                Ult = np.nanmean(rg.U[:, :, :, 0][mask_ind[:], :, :] * np.cos(lat[mask_ind[:]] * np.pi / 180)[:, None, None], axis=0)
+                Wlt = np.nanmean(rg.W[:, :, :, 0][mask_ind[:], :, :] * np.cos(lat[mask_ind[:]] * np.pi / 180)[:, None, None], axis=0)
 
     elif len(slice) == 1:
         if slice[0] in lat:
-            Meridl = z['value'][lat[:, 0] == slice[0], :, :, :]
+            Meridl = z['value'][lat[:] == slice[0], :, :, :]
             if wind_vectors == True:
-                Ul = rg.U[lat[:, 0] == slice[0], :, :, :]
-                Wl = rg.W[lat[:, 0] == slice[0], :, :, :]
+                Ul = rg.U[lat[:] == slice[0], :, :, :]
+                Wl = rg.W[lat[:] == slice[0], :, :, :]
         else:
             Meridl = np.zeros((1, len(lon), d_sig, tsp))
             if wind_vectors == True:
@@ -1443,17 +1428,17 @@ def vertical_lon(input, grid, output, rg, sigmaref, z, slice=[0, 360], save=True
     # Create figure #
     #################
     # Longitude
-    lonp = lon[:, 0] * np.pi / 180
+    lonp = lon[:] * np.pi / 180
 
     if use_p:
         # need to set desired pressure range (major PITA!)
         # prange = np.where(np.logical_and(rg.Pressure[:,0]>=np.min(Pref),rg.Pressure[:,0]<=np.max(Pref)))
-        prange = np.where(rg.Pressure[:, 0] >= np.min(Pref))
-        ycoord = rg.Pressure[prange[0], 0] / 1e5
+        prange = np.where(rg.Pressure[:] >= np.min(Pref))
+        ycoord = rg.Pressure[prange[0]] / 1e5
         zvals = Meridlt[:, prange[0]].T
     else:
-        hrange = np.where(np.logical_and(rg.Altitude[:, 0] >= np.min(sigmaref), rg.Altitude[:, 0] <= np.max(sigmaref)))
-        ycoord = rg.Altitude[hrange[0], 0] / 1000
+        hrange = np.where(np.logical_and(rg.Altitude[:] >= np.min(sigmaref), rg.Altitude[:] <= np.max(sigmaref)))
+        ycoord = rg.Altitude[hrange[0]] / 1000
         zvals = Meridlt[:, hrange[0]].T
 
     # Contour plot
@@ -1465,17 +1450,24 @@ def vertical_lon(input, grid, output, rg, sigmaref, z, slice=[0, 360], save=True
         raise IOError("clevs not valid!")
     # print(np.min(zvals),np.max(zvals))
     if isinstance(axis, axes.SubplotBase):
-        C = axis.contourf(lonp * 180 / np.pi, ycoord, zvals, clevels, cmap=z['cmap'])
         ax = axis
-    elif axis == False:
-        plt.figure(figsize=(5, 4))
-        C = plt.contourf(lonp * 180 / np.pi, ycoord, zvals, clevels, cmap=z['cmap'])
-        ax = plt.gca()
+        fig = plt.gcf()
+    elif (isinstance(axis, tuple)
+          and isinstance(axis[0], plt.Figure)
+          and isinstance(axis[1], axes.SubplotBase)):
+        fig = axis[0]
+        ax = axis[1]
+    elif axis is None:
+        fig, ax = plt.subplots(1, 1, figsize=(5, 4))
     else:
-        raise IOError("'axis = {}' but {} is not an axes.SubplotBase instance".format(axis, axis))
+        raise IOError("'axis = {}' but {} is neither an axes.SubplotBase instance nor a (axes.SubplotBase, plt.Figure) instance".format(axis, axis))
+
+    fig.set_tight_layout(True)
+
+    C = ax.contourf(lonp * 180 / np.pi, ycoord, zvals, clevels, cmap=z['cmap'])
 
     if wind_vectors == True:
-        vspacing = np.int(np.shape(rg.lon)[0] / 10)
+        vspacing = np.int(np.shape(rg.Longitude)[0] / 10)
         if use_p:
             wspacing = np.int(np.shape(rg.Pressure)[0] / 10)
             Ult = Ult[:, prange[0]]
@@ -1485,18 +1477,23 @@ def vertical_lon(input, grid, output, rg, sigmaref, z, slice=[0, 360], save=True
             wspacing = np.int(np.shape(rg.Altitude)[0] / 10)
             Ult = Ult[:, hrange[0]]
             Wlt = Wlt[:, hrange[0]]
-            yqcoord = rg.Altitude[::wspacing, 0][hrange[0]]
+            yqcoord = rg.Altitude[::wspacing][hrange[0]]
 
         Uq = Ult[::vspacing, ::wspacing].ravel()
         Wq = Wlt[::vspacing, ::wspacing].ravel()
         #preq = rg.Pressure[:,0][::spacing,::spacing].ravel()
         #latq = lati[::spacing,::spacing].ravel()
-        lonq, preq = np.meshgrid(rg.lon[::vspacing, 0], yqcoord)
+        lonq, preq = np.meshgrid(rg.Longitude[::vspacing], yqcoord)
         del Ult, Wlt
-        plt.quiver(lonq.ravel(), preq.ravel() / 1e5, Uq, Wq, color='0.5')
+        ax.quiver(lonq.ravel(), preq.ravel() / 1e5, Uq, Wq, color='0.5')
 
-    clb = plt.colorbar(C, extend='both', ax=ax)
+    divider = make_axes_locatable(ax)
+    cax = divider.append_axes('right', size='5%', pad=0.05)
+    kwargs = {'format': '%#3.4e'}
+    #clb = plt.colorbar(C, extend='both', ax=ax)
+    clb = fig.colorbar(C, cax=cax, extend='both', **kwargs)
     clb.set_label(z['label'])
+
     if isinstance(csp, list) or isinstance(csp, tuple):
         levp = csp
     else:
@@ -1509,7 +1506,8 @@ def vertical_lon(input, grid, output, rg, sigmaref, z, slice=[0, 360], save=True
                 levp = np.arange(np.ceil(np.nanmin(Meridlt[:, hrange[0]]) / csp) * csp, np.floor(np.nanmax(Meridlt[:, hrange[0]]) / csp) * csp, csp)
 
     c2 = ax.contour(lonp * 180 / np.pi, ycoord, zvals, levels=levp, colors='w', linewidths=1)
-    plt.clabel(c2, inline=False, fontsize=6, fmt='%d', use_clabeltext=True)
+    ax.clabel(c2, inline=False, fontsize=6, fmt='%d', use_clabeltext=True)
+
     for cc in C.collections:
         cc.set_edgecolor("face")  # fixes a stupid bug in matplotlib 2.0
     # ax.invert_yaxis()
@@ -1519,8 +1517,9 @@ def vertical_lon(input, grid, output, rg, sigmaref, z, slice=[0, 360], save=True
     ax.set_xlabel('Longitude (deg)')
     if use_p:
         ax.set_ylabel('Pressure (bar)')
-        ax.plot(lonp * 180 / np.pi, np.zeros_like(lonp) + np.max(output.Pressure[:, grid.nv - 1, :]) / 1e5, 'r--')
-        ax.set_ylim(np.max(rg.Pressure[prange[0], 0]) / 1e5, np.min(Pref) / 1e5)
+        #ax.plot(lonp * 180 / np.pi, np.zeros_like(lonp) + np.max(output.Pressure[:, grid.nv - 1, :]) / 1e5, 'r--')
+        #ax.set_ylim(np.max(rg.Pressure[prange[0]]) / 1e5, np.min(Pref) / 1e5)
+        ax.set_ylim(np.max(rg.Pressure[prange[0]]) / 1e5, np.min(rg.Pressure[prange[0]]) / 1e5)
 
         if ax.get_ylim()[1] > ax.get_ylim()[0]:
             ax.invert_yaxis()
@@ -1534,12 +1533,12 @@ def vertical_lon(input, grid, output, rg, sigmaref, z, slice=[0, 360], save=True
 
     if not os.path.exists(input.resultsf + '/figures'):
         os.mkdir(input.resultsf + '/figures')
-    plt.tight_layout()
+
     if use_p:
         z['name'] += '_p'
     else:
         z['name'] += '_h'
-    pfile = False
+    pfile = None
     if save == True:
         # save the plot to file designated by z
         if len(slice) == 2:
@@ -1552,22 +1551,25 @@ def vertical_lon(input, grid, output, rg, sigmaref, z, slice=[0, 360], save=True
         plt.savefig(pfile)
 
         plt.close()
+
+        pfile = str(pfile)
+
     if z['mt'] == True:
         if len(slice) == 2:
             fname = '%s_ver_i%d_l%d_lat%#.2f-%#.2f.dat' % (z['name'], output.ntsi, output.nts, slice[0], slice[1])
         else:
             fname = '%s_ver_i%d_l%d_lat%#.2f.dat' % (z['name'], output.ntsi, output.nts, slice[0])
         if use_p:
-            maketable(lonp * 180 / np.pi, rg.Pressure[prange[0], 0] / 1e5, Meridlt[:, prange[0]], 'Longitude(d)', 'Pressure(bar)', z['name'], input.resultsf, fname)
+            maketable(lonp * 180 / np.pi, rg.Pressure[prange[0]] / 1e5, Meridlt[:, prange[0]], 'Longitude(d)', 'Pressure(bar)', z['name'], input.resultsf, fname)
         else:
-            maketable(lonp * 180 / np.pi, rg.Altitude[hrange[0], 0], Meridlt[:, hrange[0]],
+            maketable(lonp * 180 / np.pi, rg.Altitude[hrange[0]], Meridlt[:, hrange[0]],
                       'Longitude(d)', 'Altitude(m)', z['name'], input.resultsf, fname)
     return pfile
 
 
 def horizontal_lev(input, grid, output, rg, Plev, z, save=True, axis=False, wind_vectors=False, use_p=True, clevs=[40]):
     # Set the latitude-longitude grid.
-    loni, lati = np.meshgrid(rg.lon[:, 0], rg.lat[:, 0])
+    loni, lati = np.meshgrid(rg.Longitude[:], rg.Latitude[:])
 
     d_lon = np.shape(loni)
     tsp = output.nts - output.ntsi + 1
@@ -1604,9 +1606,9 @@ def horizontal_lev(input, grid, output, rg, Plev, z, save=True, axis=False, wind
 
         if len(np.shape(z['value'])) == 4:
             # single level of a 3D field
-            zlev[:, :, t] = (z['value'][:, :, below, t] * (vcoord[above, t] - Plev)
-                             + z['value'][:, :, above, t] * (Plev - vcoord[below, t]))\
-                / (vcoord[above, t] - vcoord[below, t])
+            zlev[:, :, t] = (z['value'][:, :, below, t] * (vcoord[above] - Plev)
+                             + z['value'][:, :, above, t] * (Plev - vcoord[below]))\
+                             / (vcoord[above] - vcoord[below])
             if use_p:
                 title = 'Time = %#.3f-%#.3f days, Plev = %#.3f bar' % (output.time[0], output.time[-1], Plev / 1e5)
                 fname = '%s_lev%#.3fmbar_i%d_l%d' % (z['name'], Plev / 100, output.ntsi, output.nts)
@@ -1621,12 +1623,12 @@ def horizontal_lev(input, grid, output, rg, Plev, z, save=True, axis=False, wind
             wind_vectors = False
 
         if wind_vectors == True:
-            Uii[:, :, t] = (rg.U[:, :, below, t] * (vcoord[above, t] - Plev)
-                            + rg.U[:, :, above, t] * (Plev - vcoord[below, t]))\
-                / (vcoord[above, t] - vcoord[below, t])
-            Vii[:, :, t] = (rg.V[:, :, below, t] * (vcoord[above, t] - Plev)
-                            + rg.V[:, :, above, t] * (Plev - vcoord[below, t]))\
-                / (vcoord[above, t] - vcoord[below, t])
+            Uii[:, :, t] = (rg.U[:, :, below, t] * (vcoord[above] - Plev)
+                            + rg.U[:, :, above, t] * (Plev - vcoord[below]))\
+                / (vcoord[above] - vcoord[below])
+            Vii[:, :, t] = (rg.V[:, :, below, t] * (vcoord[above] - Plev)
+                            + rg.V[:, :, above, t] * (Plev - vcoord[below]))\
+                / (vcoord[above] - vcoord[below])
 
     # Averaging in time
     if tsp > 1:
@@ -1651,8 +1653,8 @@ def horizontal_lev(input, grid, output, rg, Plev, z, save=True, axis=False, wind
     # Create Figure #
     #################
 
-    lonp = rg.lon[:, 0]
-    latp = rg.lat[:, 0]
+    lonp = rg.Longitude[:]
+    latp = rg.Latitude[:]
 
     if len(clevs) == 1:
         clevels = np.int(clevs[0])
@@ -1662,20 +1664,24 @@ def horizontal_lev(input, grid, output, rg, Plev, z, save=True, axis=False, wind
         raise IOError("clevs not valid!")
     # clevels = np.linspace(900,1470,58)
     if isinstance(axis, axes.SubplotBase):
-        if z['llswap']:
-            C = axis.contourf(latp, lonp, zlevt.T, clevels, cmap=z['cmap'])
-        else:
-            C = axis.contourf(lonp, latp, zlevt, clevels, cmap=z['cmap'])
         ax = axis
-    elif axis == False:
-        plt.figure(figsize=(5, 4))
-        if z['llswap']:
-            C = plt.contourf(latp, lonp, zlevt.T, clevels, cmap=z['cmap'])
-        else:
-            C = plt.contourf(lonp, latp, zlevt, clevels, cmap=z['cmap'])
-        ax = plt.gca()
+        fig = plt.gcf()
+    elif (isinstance(axis, tuple)
+          and isinstance(axis[0], plt.Figure)
+          and isinstance(axis[1], axes.SubplotBase)):
+        fig = axis[0]
+        ax = axis[1]
+    elif axis is None:
+        fig, ax = plt.subplots(1, 1, figsize=(5, 4))
     else:
-        raise IOError("'axis = {}' but {} is not an axes.SubplotBase instance".format(axis, axis))
+        raise IOError("'axis = {}' but {} is neither an axes.SubplotBase instance nor a (axes.SubplotBase, plt.Figure) instance".format(axis, axis))
+
+    fig.set_tight_layout(True)
+
+    if z['llswap']:
+        C = ax.contourf(latp, lonp, zlevt.T, clevels, cmap=z['cmap'])
+    else:
+        C = ax.contourf(lonp, latp, zlevt, clevels, cmap=z['cmap'])
 
     for cc in C.collections:
         cc.set_edgecolor("face")  # fixes a stupid bug in matplotlib 2.0
@@ -1698,23 +1704,31 @@ def horizontal_lev(input, grid, output, rg, Plev, z, save=True, axis=False, wind
         latq = lati[::spacing, ::spacing].ravel()
         del Uiii, Viii
         if z['llswap']:
-            q = plt.quiver(latq, lonq, V, U, color='0.5')
+            q = ax.quiver(latq, lonq, V, U, color='0.5')
         else:
-            q = plt.quiver(lonq, latq, U, V, color='0.5')
+            q = ax.quiver(lonq, latq, U, V, color='0.5')
         ax.quiverkey(q, X=0.85, Y=-0.1, U=np.max(np.sqrt(U**2 + V**2)), label='%#.2f m/s' % np.max(np.sqrt(U**2 + V**2)), labelpos='E')
 
-    clb = plt.colorbar(C)
+    divider = make_axes_locatable(ax)
+    cax = divider.append_axes('right', size='5%', pad=0.05)
+    kwargs = {'format': '%#3.4e'}
+    clb = fig.colorbar(C, cax=cax, orientation='vertical', **kwargs)
     clb.set_label(z['label'])
 
-    if not os.path.exists(input.resultsf + '/figures'):
-        os.mkdir(input.resultsf + '/figures')
-    plt.tight_layout()
-    pfile = False
+
+    pfile = None
     if save == True:
-        pfile = input.resultsf + '/figures/' + fname.replace(".", "+") + '.pdf'
+        output_path = pathlib.Path(input.resultsf) / 'figures'
+        if not output_path.exists():
+            output_path.mkdir()
+
+        pfile = output_path / (fname.replace(".", "+") + '.pdf')
         plt.savefig(pfile)
 
         plt.close()
+
+        pfile = str(pfile)
+
     if z['mt'] == True:
         dname = fname + '.dat'
         if z['name'] == 'temperature-uv':
@@ -1757,28 +1771,28 @@ def streamf_moc_plot(input, grid, output, rg, sigmaref, save=True, axis=False, w
     tsp = output.nts - output.ntsi + 1
 
     if tsp > 1:
-        Vavgl = np.mean(rg.V, axis=1)
-        Vavglt = np.mean(Vavgl, axis=2)
+        Vavgl = np.nanmean(rg.V, axis=1)
+        Vavglt = np.nanmean(Vavgl, axis=2)
         if wind_vectors == True:
-            Wavgl = np.mean(rg.W, axis=1)
-            Wavglt = np.mean(Wavgl, axis=2)
+            Wavgl = np.nanmean(rg.W, axis=1)
+            Wavglt = np.nanmean(Wavgl, axis=2)
     else:
-        Vavglt = np.mean(rg.V[:, :, :, 0], axis=1)
+        Vavglt = np.nanmean(rg.V[:, :, :, 0], axis=1)
         if wind_vectors == True:
-            Wavglt = np.mean(rg.V[:, :, :, 0], axis=1)
+            Wavglt = np.nanmean(rg.V[:, :, :, 0], axis=1)
 
     sf = np.zeros_like(Vavglt)
-    arg = 2 * np.pi * input.A * np.cos(rg.lat[:, 0][:, None] * np.pi / 180) / input.Gravit * Vavglt
+    arg = 2 * np.pi * input.A * np.cos(rg.Latitude[:, None] * np.pi / 180) / input.Gravit * Vavglt
     for ilat in np.arange(np.shape(Vavglt)[0]):
         for ilev in np.arange(np.shape(Vavglt)[1]):
             if ilev == 0:
-                sf[ilat, -1] = arg[ilat, -1] * rg.Pressure[-1, 0]
+                sf[ilat, -1] = arg[ilat, -1] * rg.Pressure[-1]
             else:
-                sf[ilat, -(ilev + 1)] = np.trapz(arg[ilat, -1:-(ilev + 2):-1], x=rg.Pressure[-1:-(ilev + 2):-1][:, 0])
+                sf[ilat, -(ilev + 1)] = np.trapz(arg[ilat, -1:-(ilev + 2):-1], x=rg.Pressure[-1:-(ilev + 2):-1][:])
 
     # need to set desired pressure range (major PITA!)
     # prange = np.where(np.logical_and(rg.Pressure>=np.min(Pref),rg.Pressure<=np.max(Pref)))
-    prange = np.where(rg.Pressure[:, 0] >= np.min(Pref))
+    prange = np.where(rg.Pressure[:] >= np.min(Pref))
 
     # Contour plot
     if len(clevs) == 1:
@@ -1789,11 +1803,11 @@ def streamf_moc_plot(input, grid, output, rg, sigmaref, save=True, axis=False, w
         raise IOError("clevs not valid!")
 
     if isinstance(axis, axes.SubplotBase):
-        C = axis.contourf(rg.lat[:, 0], rg.Pressure[prange[0], 0] / 1e5, sf[:, prange[0]].T, clevels, cmap='viridis')
+        C = axis.contourf(rg.Latitude[:], rg.Pressure[prange[0]] / 1e5, sf[:, prange[0]].T, clevels, cmap='viridis')
         ax = axis
     elif axis == False:
         plt.figure(figsize=(5, 4))
-        C = plt.contourf(rg.lat[:, 0], rg.Pressure[prange[0], 0] / 1e5, sf[:, prange[0]].T, clevels, cmap='viridis')
+        C = plt.contourf(rg.Latitude[:], rg.Pressure[prange[0]] / 1e5, sf[:, prange[0]].T, clevels, cmap='viridis')
 
         ax = plt.gca()
     else:
@@ -1803,7 +1817,7 @@ def streamf_moc_plot(input, grid, output, rg, sigmaref, save=True, axis=False, w
         cc.set_edgecolor("face")  # fixes a stupid bug in matplotlib 2.0
 
     if wind_vectors == True:
-        vspacing = np.int(np.shape(rg.lat)[0] / 10)
+        vspacing = np.int(np.shape(rg.Latitude)[0] / 10)
         wspacing = np.int(np.shape(rg.Pressure)[0] / 10)
         Vlt = Vavglt[:, prange[0]]
         Wlt = Wavglt[:, prange[0]]
@@ -1811,21 +1825,21 @@ def streamf_moc_plot(input, grid, output, rg, sigmaref, save=True, axis=False, w
         Wq = Wlt[::vspacing, ::wspacing].ravel()
         #preq = rg.Pressure[:,0][::spacing,::spacing].ravel()
         #latq = lati[::spacing,::spacing].ravel()
-        latq, preq = np.meshgrid(rg.lat[::vspacing, 0], rg.Pressure[::wspacing, 0][prange[0]])
+        latq, preq = np.meshgrid(rg.Latitude[::vspacing], rg.Pressure[::wspacing][prange[0]])
         del Vlt, Wlt
         plt.quiver(latq.ravel(), preq.ravel() / 1e5, Vq, Wq, color='0.5')
 
     ax.invert_yaxis()
-    c2 = ax.contour(rg.lat[:, 0], rg.Pressure[:, 0] / 1e5, sf.T, levels=[0.0], colors='w', linewidths=1)
+    c2 = ax.contour(rg.Latitude[:], rg.Pressure[:] / 1e5, sf.T, levels=[0.0], colors='w', linewidths=1)
     clb = plt.colorbar(C)
     clb.set_label(r'Eulerian streamfunction (kg s$^{-1}$)')
     if plog == True:
         ax.set_yscale("log")
     ax.set_xlabel('Latitude (deg)')
     ax.set_ylabel('Pressure (bar)')
-    # ax.plot(rg.lat[:,0],np.zeros_like(rg.lat[:,0])+np.max(output.Pressure[:,grid.nv-1,:])/1e5,'r--')
+    # ax.plot(rg.Latitude[:,0],np.zeros_like(rg.Latitude[:,0])+np.max(output.Pressure[:,grid.nv-1,:])/1e5,'r--')
     # if np.min(rg.Pressure[prange[0],0]) < np.max(output.Pressure[:,grid.nv-1,:]):
-    ax.set_ylim(np.max(rg.Pressure[prange[0], 0]) / 1e5, np.min(rg.Pressure[prange[0], 0]) / 1e5)
+    ax.set_ylim(np.max(rg.Pressure[prange[0]]) / 1e5, np.min(rg.Pressure[prange[0]]) / 1e5)
 
     # else:
     #     ax.set_ylim(np.max(rg.Pressure[prange[0],0])/1e5,np.max(output.Pressure[:,grid.nv-1,:])/1e5)
@@ -1833,24 +1847,49 @@ def streamf_moc_plot(input, grid, output, rg, sigmaref, save=True, axis=False, w
     if not os.path.exists(input.resultsf + '/figures'):
         os.mkdir(input.resultsf + '/figures')
     plt.tight_layout()
-    pfile = False
+    pfile = None
     if save == True:
         pfile = input.resultsf + '/figures/streamf_ver_i%d_l%d.pdf' % (output.ntsi, output.nts)
         plt.savefig(pfile)
         plt.close()
+
+        pfile = str(pfile)
+
     if mt == True:
         fname = 'streamf_ver_i%d_l%d.dat' % (output.ntsi, output.nts)
-        maketable(latp * 180 / np.pi, rg.Pressure[prange[0], 0] / 1e5, Zonallt[:, prange[0]],
+        maketable(latp * 180 / np.pi, rg.Pressure[prange[0]] / 1e5, Zonallt[:, prange[0]],
                   'Latitude(d)', 'Pressure(bar)', 'streamfunc', input.resultsf, fname)
     return pfile
 
 
-def profile(input, grid, output, z, stride=50):
+def profile(input, grid, output, z, stride=50, axis=None, save=True):
     # Pref = input.P_Ref*sigmaref
     # d_sig = np.size(sigmaref)
 
+    # prepare pressure array
+    output.load_reshape(grid, ['Pressure'])
+
+    # get figure and axis
+    if isinstance(axis, axes.SubplotBase):
+        ax = axis
+        fig = plt.gcf()
+    elif (isinstance(axis, tuple)
+          and isinstance(axis[0], plt.Figure)
+          and isinstance(axis[1], axes.SubplotBase)):
+        fig = axis[0]
+        ax = axis[1]
+    elif axis is None:
+        fig, ax = plt.subplots(1, 1, figsize=(5, 4))
+    else:
+        raise IOError("'axis = {}' but {} is neither an axes.SubplotBase instance nor a (axes.SubplotBase, plt.Figure) instance".format(axis, axis))
+
+    fig.set_tight_layout(True)
+
     tsp = output.nts - output.ntsi + 1
 
+    col_lon = []
+    col_lat = []
+    col_lor = []
     for column in np.arange(0, grid.point_num, stride):
         if tsp > 1:
             P = np.mean(output.Pressure[column, :, :], axis=1)
@@ -1859,20 +1898,64 @@ def profile(input, grid, output, z, stride=50):
             P = output.Pressure[column, :, 0]
             x = z['value'][column, :, 0]
 
-        plt.semilogy(x, P / 1e5, 'k-', alpha=0.5, lw=1)
-        rp, = plt.plot(x[np.int(np.floor(grid.nv / 2))], P[np.int(np.floor(grid.nv / 2))] / 100000, 'r+', ms=5, alpha=0.5)
-        gp, = plt.plot(x[np.int(np.floor(grid.nv * 0.75))], P[np.int(np.floor(grid.nv * 0.75))] / 100000, 'g+', ms=5, alpha=0.5)
+        #color = hsv_to_rgb([column / grid.point_num, 1.0, 1.0])
+        lon = grid.lon[column]
+        lat = grid.lat[column]
+        lon_norm = lon / (2.0 * math.pi)
+        lat_norm = lat / (math.pi / 2.0)
+        if lat > 0.0:
+            color = hsv_to_rgb([lon_norm, 1.0 - 0.7 * lat_norm, 1.0])
+        else:
+            color = hsv_to_rgb([lon_norm, 1.0, 1.0 + 0.7 * lat_norm])
+
+        col_lon.append(lon)
+        col_lat.append(lat)
+        col_lor.append(color)
+        ax.semilogy(x, P / 1e5, 'k-', alpha=0.5, lw=1.0,
+                    path_effects=[pe.Stroke(linewidth=1.5, foreground=color), pe.Normal()])
+
+        rp, = ax.plot(x[np.int(np.floor(grid.nv / 2))], P[np.int(np.floor(grid.nv / 2))] / 100000, 'k+', ms=5, alpha=0.5)
+        gp, = ax.plot(x[np.int(np.floor(grid.nv * 0.75))], P[np.int(np.floor(grid.nv * 0.75))] / 100000, 'k*', ms=5, alpha=0.5)
+
+    # add an insert showing the position of
+    inset_pos = [0.8, 0.8, 0.18, 0.18]
+    ax_inset = ax.inset_axes(inset_pos)
+    ax_inset.scatter(col_lon, col_lat, c=col_lor, s=1.0)
+    ax_inset.tick_params(axis='both',
+                         which='both',
+                         top=False,
+                         bottom=False,
+                         left=False,
+                         right=False,
+                         labelright=False,
+                         labelleft=False,
+                         labeltop=False,
+                         labelbottom=False)
 
     # plt.plot(Tad,P/100,'r--')
-    plt.gca().invert_yaxis()
-    plt.ylabel('Pressure (bar)')
-    plt.xlabel(z['label'])
-    plt.legend([rp, gp], ['z=0.5*ztop', 'z=0.75*ztop'])
-    plt.title('Time = %#.3f - %#.3f days' % (output.time[0], output.time[-1]))
-    if not os.path.exists(input.resultsf + '/figures'):
-        os.mkdir(input.resultsf + '/figures')
-    plt.savefig(input.resultsf + '/figures/%sPprofile_i%d_l%d.pdf' % (z['name'], output.ntsi, output.nts))
-    plt.close()
+    ax.invert_yaxis()
+    ax.set_ylabel('Pressure (bar)')
+    ax.set_xlabel(z['label'])
+    ax.legend([rp, gp], ['z=0.5*ztop', 'z=0.75*ztop'], loc="lower right", fontsize='xx-small')
+    ax.set_title('Time = %#.3f - %#.3f days' % (output.time[0], output.time[-1]))
+    ax.get_xaxis().get_major_formatter().set_useOffset(False)
+    ax.tick_params(axis='x', labelrotation=45 )
+
+    ax.grid(True)
+    pfile = None
+    if save == True:
+        output_path = pathlib.Path(input.resultsf) / 'figures'
+        if not output_path.exists():
+            output_path.mkdir()
+
+        fname = f"{z['name']}Pprofile_i{output.ntsi}_l{output.nts}"
+        pfile = output_path / (fname.replace(".", "+") + '.pdf')
+        plt.savefig(pfile)
+
+        plt.close()
+        pfile = str(pfile)
+
+    return pfile
 
 
 def CalcE_M_AM(input, grid, output, split):
@@ -2109,6 +2192,54 @@ def SRindex(input, grid, output):
     plt.savefig(input.resultsf + '/figures/SRindex_i%d_l%d.pdf' % (output.ntsi, output.nts))
     plt.close()
 
+def phase_curve(input, grid, output, axis=None, save=True):
+    #plot phase curve, averaged over output times
+
+    # get figure and axis
+    if isinstance(axis, axes.SubplotBase):
+        ax = axis
+        fig = plt.gcf()
+    elif (isinstance(axis, tuple)
+          and isinstance(axis[0], plt.Figure)
+          and isinstance(axis[1], axes.SubplotBase)):
+        fig = axis[0]
+        ax = axis[1]
+    elif axis is None:
+        fig, ax = plt.subplots(1, 1, figsize=(5, 4))
+    else:
+        raise IOError("'axis = {}' but {} is neither an axes.SubplotBase instance nor a (axes.SubplotBase, plt.Figure) instance".format(axis, axis))
+
+    angle = np.linspace(0,2*np.pi,100)
+
+    pc = np.zeros_like(angle)
+    for j in np.arange(len(output.time)):
+        olr = output.flw_up[:,-1,j]
+        for i in np.arange(len(angle)):
+            mu = np.cos(grid.lat)*np.cos(grid.lon-angle[i])
+            mu[mu<0] = 0
+            los_flux = mu*olr
+            pc_tmp = np.sum(los_flux*grid.areasT)/np.sum(grid.areasT)
+            pc[i] = pc_tmp/(j+1)+pc[i]*(j)/(j+1)
+
+    xx = 360-((np.pi+angle)%(2*np.pi))*180/np.pi
+    ax.plot(np.sort(xx),pc[np.argsort(xx)])
+
+    ax.set_title('Time = %#.3f - %#.3f days' % (output.time[0], output.time[-1]))
+
+    ax.axvline(180,ls='--',c = 'k')
+    ax.set_xlabel('Angle relative to transit (deg)')
+    ax.set_ylabel(r'Flux (W m$^{-2}$)')
+    fig.tight_layout()
+    if save == True:
+        output_path = pathlib.Path(input.resultsf) / 'figures'
+        if not output_path.exists():
+            output_path.mkdir()
+
+        fname = f"phase_curve_i{output.ntsi}_l{output.nts}.pdf"
+        pfile = output_path / (fname.replace(".", "+") + '.pdf')
+        plt.savefig(pfile)
+
+        plt.close()
 
 def Get_Prange(input, grid, rg, args, xtype='lat', use_p=True):
     # Sigma (normalized pressure) values for the plotting
@@ -2136,3 +2267,102 @@ def RTbalance(input, grid, output):
     # not finished!
     asr = fsw_dn[:, input.nv - 1, :] * grid.areasT[:, None]
     olr = flw_up[:, input.nv - 1, :] * grid.areasT[:, None]
+
+def spectrum(input, grid, output, z, stride=20, axis=None, save=True):
+    output.load_reshape(grid, ['spectrum', 'incoming_spectrum'])
+    # get figure and axis
+    if isinstance(axis, axes.SubplotBase):
+        ax = axis
+        fig = plt.gcf()
+    elif (isinstance(axis, tuple)
+          and isinstance(axis[0], plt.Figure)
+          and isinstance(axis[1], axes.SubplotBase)):
+        fig = axis[0]
+        ax = axis[1]
+    elif axis is None:
+        fig, ax = plt.subplots(1, 1, figsize=(5, 4))
+    else:
+        raise IOError("'axis = {}' but {} is neither an axes.SubplotBase instance nor a (axes.SubplotBase, plt.Figure) instance".format(axis, axis))
+
+    fig.set_tight_layout(True)
+
+    tsp = output.nts - output.ntsi + 1
+
+
+    col_lon = []
+    col_lat = []
+    col_lor = []
+
+    for column in np.arange(0, grid.point_num, stride):
+        lamda = output.wavelength[:]*1e6
+        if tsp > 1:
+            spectrum= np.mean(output.spectrum[column, :, :], axis=1)
+        else:
+            spectrum= output.spectrum[column, :, 0]
+
+        #color = hsv_to_rgb([column / grid.point_num, 1.0, 1.0])
+        lon = grid.lon[column]
+        lat = grid.lat[column]
+        lon_norm = lon / (2.0 * math.pi)
+        lat_norm = lat / (math.pi / 2.0)
+        if lat > 0.0:
+            color = hsv_to_rgb([lon_norm, 1.0 - 0.7 * lat_norm, 1.0])
+        else:
+            color = hsv_to_rgb([lon_norm, 1.0, 1.0 + 0.7 * lat_norm])
+
+        col_lon.append(lon)
+        col_lat.append(lat)
+        col_lor.append(color)
+        ax.plot(lamda, spectrum, 'k-', alpha=0.5, lw=1.0,
+                    path_effects=[pe.Stroke(linewidth=1.5, foreground=color), pe.Normal()])
+
+    lamda = output.wavelength[:]*1e6
+    if tsp > 1:
+        incoming_spectrum= np.mean(output.incoming_spectrum[:, :], axis=1)
+    else:
+        incoming_spectrum= output.incoming_spectrum[:, 0]
+    R_SUN   = 695700000.0
+    AU       = 149597870700.0
+    flx_cst = pow((input.radius_star*R_SUN)/(input.planet_star_dist*AU), 2.0)*math.pi
+    ax_twin = ax.twinx()
+    ax_twin.plot(lamda, incoming_spectrum*flx_cst, 'k-', alpha=0.5, lw=1.0,
+            path_effects=[pe.Stroke(linewidth=1.5, foreground='black'), pe.Normal()])
+    ax_twin.set_ylabel('Incoming stellar flux [$W m^2$]')
+    # add an insert showing the position of columns
+    inset_pos = [0.8, 0.1, 0.18, 0.18]
+    ax_inset = ax.inset_axes(inset_pos)
+    ax_inset.scatter(col_lon, col_lat, c=col_lor, s=1.0)
+    ax_inset.tick_params(axis='both',
+                         which='both',
+                         top=False,
+                         bottom=False,
+                         left=False,
+                         right=False,
+                         labelright=False,
+                         labelleft=False,
+                         labeltop=False,
+                         labelbottom=False)
+
+    # plt.plot(Tad,P/100,'r--')
+    #ax.invert_yaxis()
+    ax.set_xscale('log')
+    ax.set_yscale('linear')
+    ax.set_ylabel('Flux [$W m^2$]')
+    ax.set_xlabel('Wavelength [um]')
+    ax.set_title('Time = %#.3f - %#.3f days' % (output.time[0], output.time[-1]))
+    ax.grid(True)
+
+    pfile = None
+    if save == True:
+        output_path = pathlib.Path(input.resultsf) / 'figures'
+        if not output_path.exists():
+            output_path.mkdir()
+
+        fname = f"spectrum_i{output.ntsi}_l{output.nts}"
+        pfile = output_path / (fname.replace(".", "+") + '.pdf')
+        plt.savefig(pfile)
+
+        plt.close()
+        pfile = str(pfile)
+
+    return pfile

--- a/mjolnir/mjolnir.py
+++ b/mjolnir/mjolnir.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+
+#---- code by Russell Deitrick ------------------------------------------------
+
 import numpy as np
 import argparse
 from importlib import reload
@@ -44,7 +47,7 @@ parser.add_argument("-vtop", "--vertical_top", nargs=1, default=['default'], hel
 parser.add_argument("-slay", "--split_layer", nargs=1, default=['no_split'], help='Split conserved quantities into weather and deep layers at this pressure')
 parser.add_argument("-coord", "--coordinate_sys", nargs=1, default=['icoh'], help='For KE spectrum, use either icoh grid or llp grid')
 parser.add_argument("-ladj", "--lmax_adjust", nargs=1, default=[0], help='For KE spectrum, icoh grid, adjust number of wave numbers to fit')
-parser.add_argument("-slice", "--slice", nargs='+', default=[0, 360], help='Plot a long/lat slice or average over all values', type=float)
+parser.add_argument("-slice", "--slice", nargs='+', default=['default'], help='Plot a long/lat slice or average over all values')
 parser.add_argument("-mt", "--maketable", action='store_true', help='Print a table in text file of plot data')
 parser.add_argument("-no-log", "--no_pressure_log", action='store_true', help='Switch off log coordinates in pressure (vertical)')
 parser.add_argument("-llswap", "--latlonswap", action='store_true', help='Swap latitude and longitude axes (horizontal plots)')

--- a/mjolnir/mjolnir_plot_helper.py
+++ b/mjolnir/mjolnir_plot_helper.py
@@ -54,7 +54,7 @@ def make_plot(args, save=True, axis=None):
              'TP', 'RVlev', 'cons', 'stream', 'pause', 'tracer', 'PTP', 'regrid', 'KE',
              'SR', 'uprof', 'cfl', 'bvprof', 'TSfluxprof', 'Tsurf', 'insol', 'massf', 'pause_rg', 'DGfluxprof', 'qheat',
              'DGfutprof', 'DGfdtprof', 'mustar', 'DGfuptot', 'DGfdowntot', 'DGfnet', 'DGqheat',  # alf stuff
-             'TSfutprof', 'TSfdtprof', 'mustar', 'TSfuptot', 'TSfdowntot', 'TSfnet', 'TSqheat',
+             'TSfutprof', 'TSfdtprof', 'TSfuptot', 'TSfdowntot', 'TSfnet', 'TSqheat',
              'DGqheatprof', 'TSqheatprof', 'qheatprof', 'TSfdirprof',
              'w0prof', 'g0prof', 'spectrum',
              'phase','all','eddyKE','eddyMomMerid','eddyTempMerid','eddyTempVar',

--- a/mjolnir/mjolnir_plot_helper.py
+++ b/mjolnir/mjolnir_plot_helper.py
@@ -1,7 +1,12 @@
+#---- code by Russell Deitrick and Urs Schroffenegger---------------------------
+
 import hamarr as ham
 import subprocess as spr
 import numpy as np
+import sys
+import traceback
 
+import math
 
 class mjol_args:
     # make_plot args, populate with defaults
@@ -16,16 +21,28 @@ class mjol_args:
         self.split_layer = ['no_split']
         self.coordinate_sys = ['icoh']
         self.lmax_adjust = [0]
-        self.slice = [0, 360]
+        self.slice = ['default']
         self.maketable = False
         self.no_pressure_log = False
         self.latlonswap = False
         self.vcoord = ['pressure']
         self.pgrid_ref = ['auto']
         self.clevels = [40]
+        self.band = None
+
+def call_plot(name, func, *args, **kwargs):
+    try:
+        pfile = func(*args,**kwargs)
+        if pfile is not None:
+            print('Created file: ' + str(pfile))
+        return pfile
+    except:
+        print(traceback.format_exc())
+        print(f'{name} plot FAILED')
+        return None
 
 
-def make_plot(args):
+def make_plot(args, save=True, axis=None):
     pview = args.pview
 
     maketable = args.maketable
@@ -35,24 +52,29 @@ def make_plot(args):
 
     valid = ['uver', 'ulonver', 'vver', 'wver', 'wlonver', 'wprof', 'Tver', 'Tlonver', 'Tulev', 'PTver', 'PTlonver', 'ulev', 'PVver', 'PVlev',
              'TP', 'RVlev', 'cons', 'stream', 'pause', 'tracer', 'PTP', 'regrid', 'KE',
-             'SR', 'uprof', 'cfl', 'bvprof', 'fluxprof', 'Tsurf', 'insol', 'massf',
-             'futprof', 'fdtprof', 'fnetprof', 'mustar', 'fuptot', 'fdowntot', 'fnet', 'qheat',  # alf stuff
-             'pause_rg', 'Etotlev','AngMomlev', 'Entropylev']
+             'SR', 'uprof', 'cfl', 'bvprof', 'TSfluxprof', 'Tsurf', 'insol', 'massf', 'pause_rg', 'DGfluxprof', 'qheat',
+             'DGfutprof', 'DGfdtprof', 'mustar', 'DGfuptot', 'DGfdowntot', 'DGfnet', 'DGqheat',  # alf stuff
+             'TSfutprof', 'TSfdtprof', 'mustar', 'TSfuptot', 'TSfdowntot', 'TSfnet', 'TSqheat',
+             'DGqheatprof', 'TSqheatprof', 'qheatprof', 'TSfdirprof',
+             'w0prof', 'g0prof', 'spectrum',
+             'phase','all','eddyKE','eddyMomMerid','eddyTempMerid','eddyTempVar',
+             'Etotlev','AngMomlev', 'Entropylev']
 
     rg_needed = ['Tver', 'Tlonver', 'uver', 'ulonver', 'vver', 'wver', 'wlonver', 'Tulev', 'PTver', 'PTlonver', 'ulev', 'PVver', 'PVlev',
-                 'RVlev', 'stream', 'tracer', 'Tsurf', 'insol', 'massf',
-                 'mustar', 'fuptot', 'fdowntot', 'fnet', 'qheat', 'pause_rg', 'Etotlev', 'AngMomlev', 'Entropylev']  # these types need regrid
+                 'RVlev', 'stream', 'tracer', 'Tsurf', 'insol', 'massf', 'pause_rg',
+                 'mustar', 'qheat',
+                 'TSfuptot', 'TSfdowntot', 'TSfnet', 'TSqheat',
+                 'DGfuptot', 'DGfdowntot', 'DGfnet', 'DGqheat',
+                 'all','eddyKE','eddyMomMerid','eddyTempMerid','eddyTempVar',
+                  'Etotlev', 'AngMomlev', 'Entropylev']  # these types need regrid
 
     openrg = 0
-    if 'all' in pview:
-        pview = valid
-        openrg = 1
-    else:
-        for p in pview:
-            if openrg == 0 and p in rg_needed:
-                openrg = 1
-            if p not in valid:
-                raise ValueError('%s not a valid plot option. Valid options are ' % p + ', '.join(valid))
+
+    for p in pview:
+        if openrg == 0 and p in rg_needed:
+            openrg = 1
+        if p not in valid:
+            raise ValueError('%s not a valid plot option. Valid options are ' % p + ', '.join(valid))
 
     ntsi = args.initial_file[0]  # initial file id number
 
@@ -124,307 +146,391 @@ def make_plot(args):
 
     plots_created = []
     # --- Vertical plot types-------------------------------
-    if 'uver' in pview:
+    if 'uver' in pview or 'all' in pview:
+        rg.load(['U'])  #load these arrays into memory
         z = {'value': rg.U, 'label': r'Velocity (m s$^{-1}$)', 'name': 'u',
-             'cmap': 'viridis', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'plog': plog}
+             'cmap': 'viridis', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'plog': plog}
         sigmaref = ham.Get_Prange(input, grid, rg, args, xtype='lat', use_p=use_p)
-        # Averaged zonal winds (latitude vs pressure)
-        # ham.u(input,grid,output,rg,sigmaref,slice=args.slice[0])
-        pfile = ham.vertical_lat(input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, csp=1000, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
-    if 'ulonver' in pview:
+        pfile = call_plot('uver',ham.vertical_lat,input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, csp=1000, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if 'ulonver' in pview or 'all' in pview:
+        rg.load(['U'])
         z = {'value': rg.U, 'label': r'Velocity (m s$^{-1}$)', 'name': 'u',
-             'cmap': 'viridis', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'plog': plog}
+             'cmap': 'viridis', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'plog': plog}
         sigmaref = ham.Get_Prange(input, grid, rg, args, xtype='lat', use_p=use_p)
-        # Averaged zonal winds (latitude vs pressure)
-        # ham.u(input,grid,output,rg,sigmaref,slice=args.slice[0])
-        pfile = ham.vertical_lon(input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, csp=1000, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
-    if 'vver' in pview:
+        pfile = call_plot('ulonver',ham.vertical_lon,input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, csp=1000, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if 'vver' in pview or 'all' in pview:
+        rg.load(['V'])
         z = {'value': rg.V, 'label': r'Velocity (m s$^{-1}$)', 'name': 'v',
-             'cmap': 'viridis', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'plog': plog}
+             'cmap': 'viridis', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'plog': plog}
         sigmaref = ham.Get_Prange(input, grid, rg, args, xtype='lat', use_p=use_p)
-        # Averaged zonal winds (latitude vs pressure)
-        # ham.u(input,grid,output,rg,sigmaref,slice=args.slice[0])
-        pfile = ham.vertical_lat(input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
-    if 'wver' in pview:
+        pfile = call_plot('vver',ham.vertical_lat,input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if 'wver' in pview or 'all' in pview:
+        rg.load(['W'])
         z = {'value': rg.W, 'label': r'Velocity (m s$^{-1}$)', 'name': 'w',
-             'cmap': 'viridis', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'plog': plog}
+             'cmap': 'viridis', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'plog': plog}
         sigmaref = ham.Get_Prange(input, grid, rg, args, xtype='lat', use_p=use_p)
-        # Averaged vertical winds (latitude vs pressure)
-        # ham.w_ver(input,grid,output,rg,sigmaref)
-        pfile = ham.vertical_lat(input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, csp=1, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
-    if 'wlonver' in pview:
+        pfile = call_plot('wver',ham.vertical_lat,input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, csp=1, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if 'wlonver' in pview or 'all' in pview:
+        rg.load(['W'])
         z = {'value': rg.W, 'label': r'Velocity (m s$^{-1}$)', 'name': 'w',
-             'cmap': 'viridis', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'plog': plog}
+             'cmap': 'viridis', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'plog': plog}
         sigmaref = ham.Get_Prange(input, grid, rg, args, xtype='lat', use_p=use_p)
-        # Averaged zonal winds (latitude vs pressure)
-        # ham.u(input,grid,output,rg,sigmaref,slice=args.slice[0])
-        pfile = ham.vertical_lon(input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, csp=5, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
-    if 'Tver' in pview:
+        pfile = call_plot('wlonver',ham.vertical_lon,input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, csp=5, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if 'Tver' in pview or 'all' in pview:
+        rg.load(['Temperature'])
         z = {'value': rg.Temperature, 'label': r'Temperature (K)', 'name': 'temperature',
-             'cmap': 'magma', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'plog': plog}
+             'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'plog': plog}
         sigmaref = ham.Get_Prange(input, grid, rg, args, xtype='lat', use_p=use_p)
-        # Averaged temperature (latitude vs pressure)
-        # ham.temperature(input,grid,output,rg,sigmaref)
-        pfile = ham.vertical_lat(input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, csp=[0], clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
-    if 'Tlonver' in pview:
+        pfile = call_plot('Tver',ham.vertical_lat,input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, csp=[0], clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if 'Tlonver' in pview or 'all' in pview:
         z = {'value': rg.Temperature, 'label': r'Temperature (K)', 'name': 'temperature',
-             'cmap': 'magma', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'plog': plog}
+             'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'plog': plog}
         sigmaref = ham.Get_Prange(input, grid, rg, args, xtype='lat', use_p=use_p)
-        # Averaged temperature (latitude vs pressure)
-        # ham.temperature(input,grid,output,rg,sigmaref)
-        pfile = ham.vertical_lon(input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, csp=[0], clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
-    if 'PTver' in pview:
+        pfile = call_plot('Tlonver',ham.vertical_lon,input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, csp=[0], clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if 'PTver' in pview or 'all' in pview:
+        rg.load(['Temperature','Pressure'])
         kappa_ad = input.Rd / input.Cp  # adiabatic coefficient
         pt = rg.Temperature * (rg.Pressure / input.P_Ref)**(-kappa_ad)
         z = {'value': pt, 'label': r'Potential Temperature (K)', 'name': 'potential_temp',
-             'cmap': 'plasma', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'plog': plog}
+             'cmap': 'plasma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'plog': plog}
         sigmaref = ham.Get_Prange(input, grid, rg, args, xtype='lat', use_p=use_p)
-        # Averaged potential temperature (latitude vs pressure)
-        pfile = ham.vertical_lat(input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, csp=5000, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
-    if 'PTlonver' in pview:
+        pfile = call_plot('PTver',ham.vertical_lat,input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, csp=5000, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if 'PTlonver' in pview or 'all' in pview:
+        rg.load(['Temperature','Pressure'])
         kappa_ad = input.Rd / input.Cp  # adiabatic coefficient
         pt = rg.Temperature * (rg.Pressure / input.P_Ref)**(-kappa_ad)
         z = {'value': pt, 'label': r'Potential Temperature (K)', 'name': 'potential_temp',
-             'cmap': 'plasma', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'plog': plog}
+             'cmap': 'plasma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'plog': plog}
         sigmaref = ham.Get_Prange(input, grid, rg, args, xtype='lat', use_p=use_p)
-        # Averaged potential temperature (latitude vs pressure)
-        pfile = ham.vertical_lon(input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, csp=5000, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
-    if 'PVver' in pview:
+        pfile = call_plot('PTlonver',ham.vertical_lon,input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, csp=5000, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if 'PVver' in pview or 'all' in pview:
+        rg.load(['PV'])
         # sigmaref = np.arange(1,0,)
         z = {'value': rg.PV, 'label': r'Potential Vorticity (K m$^2$ kg$^{-1}$ s$^{-1}$)',
-             'name': 'pot_vort', 'cmap': 'viridis', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'plog': plog}
+             'name': 'pot_vort', 'cmap': 'viridis', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'plog': plog}
         sigmaref = ham.Get_Prange(input, grid, rg, args, xtype='lat', use_p=use_p)
-        pfile = ham.vertical_lat(input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, clevs=args.clevels)
-        # ham.potential_vort_vert(input,grid,output,sigmaref)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
-    if 'stream' in pview:  # RD: needs some work! to adapt to height coordinate
+        pfile = call_plot('PVver',ham.vertical_lat,input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if 'stream' in pview or 'all' in pview:  # RD: needs some work! to adapt to height coordinate
         # strm = ham.calc_moc_streamf(input,grid,output)
         # strm = rg.streamf
         # z = {'value':strm, 'label':r'Eulerian streamfunction (kg s$^{-1}$)', 'name':'streamf2',
-        #      'cmap':'viridis', 'lat':rg.lat, 'lon':rg.lon}
+        #      'cmap':'viridis', 'lat':rg.Latitude, 'lon':rg.Longitude}
         if use_p:
+            rg.load(['V','W'])
             sigmaref = ham.Get_Prange(input, grid, rg, args, xtype='lat', use_p=use_p)
-            # ham.vertical_lat(input,grid,output,rg,sigmaref,z,slice=args.slice,csp=[0])
-            pfile = ham.streamf_moc_plot(input, grid, output, rg, sigmaref, mt=maketable, plog=plog, clevs=args.clevels)
-            if pfile:
-                print('Created file: ' + pfile)
-                plots_created.append(pfile)
+            pfile = call_plot('stream',ham.streamf_moc_plot,input, grid, output, rg, sigmaref, mt=maketable, plog=plog, clevs=args.clevels, save=save)
         else:
-            raise ValueError("'stream' plot type requires -vc pressure")
+            pfile = "'stream' plot type requires -vc pressure; plot not created"
+            print(pfile)
+        plots_created.append(pfile)
             # no reason to keep this way, just need to fix to use height
-    if 'massf' in pview:
+
+    if 'massf' in pview or 'all' in pview:
         if use_p == False:
             # mass flow rate (zonal average)
-            massfdl = (input.A + rg.Altitude[None, None, :, :]) * np.cos(rg.lat[:, None, None, :] * np.pi / 180) / (2 * np.pi) * rg.Rho * rg.V
+            rg.load(['Rho','V'])
+            massfdl = (input.A + rg.Altitude[None, None, :, None]) * np.cos(rg.Latitude[:, None, None, None] * np.pi / 180) / (2 * np.pi) * rg.Rho * rg.V
             z = {'value': massfdl, 'label': r'Mass flow', 'name': 'massf',
-                 'cmap': 'magma', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'plog': plog}
+                 'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'plog': plog}
             sigmaref = ham.Get_Prange(input, grid, rg, args, xtype='lat', use_p=use_p)
-            pfile = ham.vertical_lat(input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, csp=[0], clevs=args.clevels)
-            if pfile:
-                print('Created file: ' + pfile)
-                plots_created.append(pfile)
+            pfile = call_plot('massf',ham.vertical_lat,input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, csp=[0], clevs=args.clevels, save=save, axis=axis)
         else:
-            raise ValueError("'massf' plot type requires -vc height")
+            pfile = "'massf' plot type requires -vc height; plot not created"
+            print(pfile)
+        plots_created.append(pfile)
+
+    if 'eddyKE' in pview or 'all' in pview:
+        rg.load(['U','V','W'])
+        uprime = rg.U - np.mean(rg.U,axis=1)[:,None,:,:]
+        vprime = rg.V - np.mean(rg.V,axis=1)[:,None,:,:]
+        wprime = rg.W - np.mean(rg.W,axis=1)[:,None,:,:]
+        eddyKE = 0.5*(uprime**2+vprime**2+wprime**2)
+        z = {'value': eddyKE, 'label': r'Eddy KE (m$^2$ s$^{-2}$)', 'name': 'eddyKE','cmap': 'viridis',
+            'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'plog': plog}
+        sigmaref = ham.Get_Prange(input, grid, rg, args, xtype='lat', use_p=use_p)
+        pfile = call_plot('eddyKE',ham.vertical_lat,input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if 'eddyMomMerid' in pview or 'all' in pview:
+        rg.load(['U','V'])
+        uprime = rg.U - np.mean(rg.U,axis=1)[:,None,:,:]
+        vprime = rg.V - np.mean(rg.V,axis=1)[:,None,:,:]
+        eddyMom = uprime*vprime
+        z = {'value': eddyMom, 'label': r'Merid. Eddy Mom. flux (m$^2$ s$^{-2}$)', 'name': 'eddyMom','cmap': 'viridis',
+            'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'plog': plog}
+        sigmaref = ham.Get_Prange(input, grid, rg, args, xtype='lat', use_p=use_p)
+        pfile = call_plot('eddyMomMerid',ham.vertical_lat,input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if 'eddyTempMerid' in pview or 'all' in pview:
+        rg.load(['Temperature','V'])
+        Tprime = rg.Temperature - np.mean(rg.Temperature,axis=1)[:,None,:,:]
+        vprime = rg.V - np.mean(rg.V,axis=1)[:,None,:,:]
+        eddyTemp = Tprime*vprime
+        z = {'value': eddyTemp, 'label': r'Merid. Eddy temp. flux (K m$ s$^{-1}$)', 'name': 'eddyTemp','cmap': 'magma',
+            'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'plog': plog}
+        sigmaref = ham.Get_Prange(input, grid, rg, args, xtype='lat', use_p=use_p)
+        pfile = call_plot('eddyTempMerid',ham.vertical_lat,input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if 'eddyTempVar' in pview or 'all' in pview:
+        rg.load(['Temperature'])
+        Tprime = rg.Temperature - np.mean(rg.Temperature,axis=1)[:,None,:,:]
+        eddyTempV = Tprime*Tprime
+        z = {'value': eddyTempV, 'label': r'Eddy temp. variance (K$^{2}$)', 'name': 'eddyTempVar','cmap': 'magma',
+            'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'plog': plog}
+        sigmaref = ham.Get_Prange(input, grid, rg, args, xtype='lat', use_p=use_p)
+        pfile = call_plot('eddyTempVar',ham.vertical_lat,input, grid, output, rg, sigmaref, z, slice=args.slice, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
 
     # --- Horizontal plot types-------------------------------
     # need to be updated for height coordinates
-    if 'Tulev' in pview:
+    if 'Tulev' in pview or 'all' in pview:
         # Averaged temperature and wind field (longitude vs latitude)
         # PR_LV - Pressure level (Pa)
+        rg.load(['Temperature','U','V'])
         if use_p:
             PR_LV = np.float(args.horizontal_lev[0]) * 100
         else:
             PR_LV = np.float(args.horizontal_lev[0]) * 1000
         z = {'value': rg.Temperature, 'label': r'Temperature (K)', 'name': 'temperature-uv',
-             'cmap': 'magma', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'llswap': args.latlonswap}
-        pfile = ham.horizontal_lev(input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
-    if 'ulev' in pview:
+             'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('Tulev',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if 'ulev' in pview or 'all' in pview:
+        rg.load(['U','V'])
         if use_p:
             PR_LV = np.float(args.horizontal_lev[0]) * 100
         else:
             PR_LV = np.float(args.horizontal_lev[0]) * 1000
         z = {'value': rg.U, 'label': r'Zonal Velocity (m s$^{-1}$)', 'name': 'u',
-             'cmap': 'viridis', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'llswap': args.latlonswap}
-        pfile = ham.horizontal_lev(input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
+             'cmap': 'viridis', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('ulev-U',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
         z = {'value': rg.V, 'label': r'Meridional Velocity (m s$^{-1}$)', 'name': 'v',
-             'cmap': 'viridis', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'llswap': args.latlonswap}
-        pfile = ham.horizontal_lev(input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
-    if 'PVlev' in pview:
+             'cmap': 'viridis', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('ulev-V',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if 'PVlev' in pview or 'all' in pview:
+        rg.load(['PV','U','V'])
         if use_p:
             PR_LV = np.float(args.horizontal_lev[0]) * 100
         else:
             PR_LV = np.float(args.horizontal_lev[0]) * 1000
         z = {'value': rg.PV, 'label': r'Potential Vorticity (K m$^2$ kg$^{-1}$ s$^{-1}$)',
-             'name': 'pot_vort', 'cmap': 'viridis', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'llswap': args.latlonswap}
-        pfile = ham.horizontal_lev(input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
-        # ham.potential_vort_lev(input,grid,output,PR_LV)
-    if 'RVlev' in pview:
+             'name': 'pot_vort', 'cmap': 'viridis', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('PVlev',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if 'RVlev' in pview or 'all' in pview:
+        rg.load(['RVw','U','V'])
         if use_p:
             PR_LV = np.float(args.horizontal_lev[0]) * 100
         else:
             PR_LV = np.float(args.horizontal_lev[0]) * 1000
-        z = {'value': rg.RV, 'label': r'Relative Vorticity (s$^{-1}$)',
-             'name': 'rela_vort', 'cmap': 'viridis', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'llswap': args.latlonswap}
-        pfile = ham.horizontal_lev(input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
-        # ham.rela_vort_lev(input,grid,output,PR_LV)
-    if 'tracer' in pview:
+        z = {'value': rg.RVw, 'label': r'Relative Vorticity (s$^{-1}$)',
+             'name': 'rela_vort', 'cmap': 'viridis', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('RVlev',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if ('tracer' in pview or 'all' in pview) and input.chemistry:
+        rg.load(['ch4','co','h2o','co2','nh3'])
         if use_p:
             PR_LV = np.float(args.horizontal_lev[0]) * 100
         else:
             PR_LV = np.float(args.horizontal_lev[0]) * 1000
         z = {'value': np.log10(rg.ch4), 'label': r'Log(mixing ratio)',
-             'name': 'chem-ch4-uv1', 'cmap': 'magma', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'llswap': args.latlonswap}
-        pfile = ham.horizontal_lev(input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
+             'name': 'chem-ch4-uv1', 'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('tracer-ch4',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
         z = {'value': np.log10(rg.co), 'label': r'Log(mixing ratio)',
-             'name': 'chem-co-uv1', 'cmap': 'magma', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'llswap': args.latlonswap}
-        pfile = ham.horizontal_lev(input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
+             'name': 'chem-co-uv1', 'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('tracer-co',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
         z = {'value': np.log10(rg.h2o), 'label': r'Log(mixing ratio)',
-             'name': 'chem-h2o-uv1', 'cmap': 'magma', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'llswap': args.latlonswap}
-        pfile = ham.horizontal_lev(input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
+             'name': 'chem-h2o-uv1', 'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('tracer-h2o',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
         z = {'value': np.log10(rg.co2), 'label': r'Log(mixing ratio)',
-             'name': 'chem-co2-uv1', 'cmap': 'magma', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'llswap': args.latlonswap}
-        pfile = ham.horizontal_lev(input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
+             'name': 'chem-co2-uv1', 'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('tracer-co2',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
         z = {'value': np.log10(rg.nh3), 'label': r'Log(mixing ratio)',
-             'name': 'chem-nh3-uv1', 'cmap': 'magma', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'llswap': args.latlonswap}
-        pfile = ham.horizontal_lev(input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
-    if 'insol' in pview:
+             'name': 'chem-nh3-uv1', 'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('tracer-nh3',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if ('insol' in pview or 'all' in pview) and (input.RT or input.TSRT):
+        rg.load(['insol'])
         PR_LV = np.max(output.Pressure)  # not important here
         z = {'value': rg.insol, 'label': r'Insolation (W m$^{-2}$)', 'name': 'insol',
-             'cmap': 'magma', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'llswap': args.latlonswap}
-        pfile = ham.horizontal_lev(input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
-    if 'Tsurf' in pview:
+             'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('insol',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if ('Tsurf' in pview or 'all' in pview) and (input.RT or input.TSRT):
         if not hasattr(rg, "Tsurface"):
             raise ValueError("'Tsurface' not available in regrid file")
+        rg.load(['Tsurface'])
         PR_LV = np.max(output.Pressure)  # not important here
         z = {'value': rg.Tsurface, 'label': r'Surface Temperature (K)', 'name': 'Tsurf',
-             'cmap': 'magma', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'llswap': args.latlonswap}
-        pfile = ham.horizontal_lev(input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
+             'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('Tsurf',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
 
-    if 'fuptot' in pview:
+    if ('DGfuptot' in pview or 'all' in pview) and input.RT:
         # Averaged temperature and wind field (longitude vs latitude)
         # PR_LV - Pressure level (Pa)
         if use_p:
             PR_LV = np.float(args.horizontal_lev[0]) * 100
         else:
             PR_LV = np.float(args.horizontal_lev[0]) * 1000
-        z = {'value': rg.f_up_tot, 'label': r'Total upward flux (W m^-2)', 'name': 'fuptot',
-             'cmap': 'magma', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'llswap': args.latlonswap}
-        pfile = ham.horizontal_lev(input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
-    if 'fdowntot' in pview:
+
+        rg.load(['flw_up'])
+        fup = rg.flw_up
+        z = {'value': fup, 'label': r'Double Gray Total upward flux (W m^-2)', 'name': 'DGfuptot',
+             'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('DGfuptot',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if ('TSfuptot' in pview or 'all' in pview) and input.TSRT:
         # Averaged temperature and wind field (longitude vs latitude)
         # PR_LV - Pressure level (Pa)
         if use_p:
             PR_LV = np.float(args.horizontal_lev[0]) * 100
         else:
             PR_LV = np.float(args.horizontal_lev[0]) * 1000
-        z = {'value': rg.f_down_tot, 'label': r'Total downward flux (W m^-2)', 'name': 'fdowntot',
-             'cmap': 'magma', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'llswap': args.latlonswap}
-        pfile = ham.horizontal_lev(input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
-    if 'fnet' in pview:
+
+        rg.load(['f_up_tot'])
+        fup = rg.f_up_tot
+        z = {'value': fup, 'label': r'Two Streams Total upward flux (W m^-2)', 'name': 'TSfuptot',
+             'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('TSfuptot',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+
+    if ('DGfdowntot' in pview or 'all' in pview) and input.RT: #add all later
         # Averaged temperature and wind field (longitude vs latitude)
         # PR_LV - Pressure level (Pa)
         if use_p:
             PR_LV = np.float(args.horizontal_lev[0]) * 100
         else:
             PR_LV = np.float(args.horizontal_lev[0]) * 1000
-        z = {'value': rg.f_net, 'label': r'Total net flux (W m^-2)', 'name': 'fnet',
-             'cmap': 'magma', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'llswap': args.latlonswap}
-        pfile = ham.horizontal_lev(input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
-    if 'qheat' in pview:
+
+        rg.load(['flw_dn','fsw_dn'])
+        fdn = rg.flw_dn + rg.fsw_dn
+
+        z = {'value': fdn, 'label': r'Double Gray Total downward flux (W m^-2)', 'name': 'DGfdowntot',
+             'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('DGfdowntot',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if ('TSfdowntot' in pview or 'all' in pview) and input.TSRT: #add all later
         # Averaged temperature and wind field (longitude vs latitude)
         # PR_LV - Pressure level (Pa)
         if use_p:
             PR_LV = np.float(args.horizontal_lev[0]) * 100
         else:
             PR_LV = np.float(args.horizontal_lev[0]) * 1000
-        z = {'value': rg.q_heat, 'label': r'Q Heat (W m^-3)', 'name': 'qheat',
-             'cmap': 'magma', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'llswap': args.latlonswap}
-        pfile = ham.horizontal_lev(input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
-    if 'mustar' in pview:
+        rg.load(['f_down_tot'])
+        fdn = rg.f_down_tot
+        z = {'value': fdn, 'label': r'Two Streams Total downward flux (W m^-2)', 'name': 'TSfdowntot',
+             'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('TSfdowntot',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+
+    if ('DGfnet' in pview or 'all' in pview)  and input.RT:
+        # Averaged temperature and wind field (longitude vs latitude)
+        # PR_LV - Pressure level (Pa)
+        if use_p:
+            PR_LV = np.float(args.horizontal_lev[0]) * 100
+        else:
+            PR_LV = np.float(args.horizontal_lev[0]) * 1000
+        rg.load(['DGf_net'])
+        z = {'value': rg.DGf_net, 'label': r'Double Gray Total net flux (W m^-2)', 'name': 'DGfnet',
+             'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('DGfnet',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if ('TSfnet' in pview or 'all' in pview)  and input.TSRT:
+        # Averaged temperature and wind field (longitude vs latitude)
+        # PR_LV - Pressure level (Pa)
+        if use_p:
+            PR_LV = np.float(args.horizontal_lev[0]) * 100
+        else:
+            PR_LV = np.float(args.horizontal_lev[0]) * 1000
+        rg.load(['TSf_net'])
+        z = {'value': rg.TSf_net, 'label': r'Two Streams Total net flux (W m^-2)', 'name': 'TSfnet',
+             'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('TSfnet',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if ('qheat' in pview) and (input.RT or input.TSRT):
+        # Averaged temperature and wind field (longitude vs latitude)
+        # PR_LV - Pressure level (Pa)
+        if use_p:
+            PR_LV = np.float(args.horizontal_lev[0]) * 100
+        else:
+            PR_LV = np.float(args.horizontal_lev[0]) * 1000
+        z = {'value': rg.qheat, 'label': r'Q Heat (W m^-3)', 'name': 'qheat',
+             'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('qheat',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if ('DGqheat' in pview) and input.RT:
+        # Averaged temperature and wind field (longitude vs latitude)
+        # PR_LV - Pressure level (Pa)
+        if use_p:
+            PR_LV = np.float(args.horizontal_lev[0]) * 100
+        else:
+            PR_LV = np.float(args.horizontal_lev[0]) * 1000
+        z = {'value': rg.DGqheat, 'label': r'Double Gray Q Heat (W m^-3)', 'name': 'DGqheat',
+             'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('DGqheat',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if ('TSqheat' in pview) and input.TSRT:
+        # Averaged temperature and wind field (longitude vs latitude)
+        # PR_LV - Pressure level (Pa)
+        if use_p:
+            PR_LV = np.float(args.horizontal_lev[0]) * 100
+        else:
+            PR_LV = np.float(args.horizontal_lev[0]) * 1000
+        z = {'value': rg.TSqheat, 'label': r'Q Heat (W m^-3)', 'name': 'TSqheat',
+             'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('TSqheat',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if ('mustar' in pview) and (input.TSRT):
         PR_LV = np.max(output.Pressure)  # not important here
         z = {'value': rg.mustar, 'label': r'mu_star ', 'name': 'mustar',
-             'cmap': 'magma', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'llswap': args.latlonswap}
-        pfile = ham.horizontal_lev(input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
+             'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('mustar',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=True, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
     if 'Etotlev' in pview:
         # Averaged temperature and wind field (longitude vs latitude)
         # PR_LV - Pressure level (Pa)
@@ -433,11 +539,10 @@ def make_plot(args):
         else:
             PR_LV = np.float(args.horizontal_lev[0]) * 1000
         z = {'value': rg.Etotal, 'label': r'Total energy (J m$^{-3}$)', 'name': 'Etotal',
-             'cmap': 'magma', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'llswap': args.latlonswap}
-        pfile = ham.horizontal_lev(input, grid, output, rg, PR_LV, z, wind_vectors=False, use_p=use_p, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
+             'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('Etotlev',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=False, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
     if 'Entropylev' in pview:
         # Averaged temperature and wind field (longitude vs latitude)
         # PR_LV - Pressure level (Pa)
@@ -446,11 +551,10 @@ def make_plot(args):
         else:
             PR_LV = np.float(args.horizontal_lev[0]) * 1000
         z = {'value': rg.Entropy, 'label': r'Entropy (J K$^{-1}$ m$^{-3}$)', 'name': 'Entropy',
-             'cmap': 'magma', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'llswap': args.latlonswap}
-        pfile = ham.horizontal_lev(input, grid, output, rg, PR_LV, z, wind_vectors=False, use_p=use_p, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
+             'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('Entropylev',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=False, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
+
     if 'AngMomlev' in pview:
         # Averaged temperature and wind field (longitude vs latitude)
         # PR_LV - Pressure level (Pa)
@@ -459,68 +563,200 @@ def make_plot(args):
         else:
             PR_LV = np.float(args.horizontal_lev[0]) * 1000
         z = {'value': rg.AngMomz, 'label': r'Axial Angular Momentum (kg m$^{-1}$ s$^{-1}$)', 'name': 'AngMomz',
-             'cmap': 'magma', 'lat': rg.lat, 'lon': rg.lon, 'mt': maketable, 'llswap': args.latlonswap}
-        pfile = ham.horizontal_lev(input, grid, output, rg, PR_LV, z, wind_vectors=False, use_p=use_p, clevs=args.clevels)
-        if pfile:
-            print('Created file: ' + pfile)
-            plots_created.append(pfile)
+             'cmap': 'magma', 'lat': rg.Latitude, 'lon': rg.Longitude, 'mt': maketable, 'llswap': args.latlonswap}
+        pfile = call_plot('AngMomlev',ham.horizontal_lev,input, grid, output, rg, PR_LV, z, wind_vectors=False, use_p=use_p, clevs=args.clevels, save=save, axis=axis)
+        plots_created.append(pfile)
 
+    if ('spectrum' in pview) and (input.TSRT):
+        z = {'label': r'spectrum ', 'name': 'spectrum',
+             'cmap': 'magma', 'mt': maketable}
+        pfile = call_plot('spectrum',ham.spectrum, input, grid, output, z, save=save, axis=axis)
+        plots_created.append(pfile)
 
     # --- Pressure profile types-------------------------------
-    if 'TP' in pview:
+    if 'TP' in pview or 'all' in pview:
+        output.load_reshape(grid,['Pressure','Rd','Rho'])
         z = {'value': output.Pressure / output.Rd / output.Rho, 'label': 'Temperature (K)', 'name': 'T'}
         # ham.TPprof(input,grid,output,sigmaref,1902)
-        ham.profile(input, grid, output, z)
-    if 'PTP' in pview:
+        pfile = call_plot('TP',ham.profile,input, grid, output, z, stride=20, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if 'PTP' in pview or 'all' in pview:
+        output.load_reshape(grid,['Pressure','Rd','Rho','Cp'])
         # kappa_ad = input.Rd/input.Cp  # adiabatic coefficient
         kappa_ad = output.Rd / output.Cp
         T = output.Pressure / input.Rd / output.Rho
         pt = T * (output.Pressure / input.P_Ref)**(-kappa_ad)
         z = {'value': pt, 'label': 'Potential Temperature (K)', 'name': 'PT'}
-        ham.profile(input, grid, output, z)
-    if 'wprof' in pview:  # RD: needs some work!
+        pfile = call_plot('PTP',ham.profile,input, grid, output, z, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if 'wprof' in pview or 'all' in pview:  # RD: needs some work!
+        output.load_reshape(grid,['Wh','Pressure', 'Rho'])
         z = {'value': output.Wh[:, 1:, :] / output.Rho, 'label': r'Vertical velocity (m s$^{-1}$)', 'name': 'W'}
-        ham.profile(input, grid, output, z, stride=20)
-        # Averaged vertical winds (latitude vs pressure)
-        # ham.w_prof(input,grid,output)
-    if 'uprof' in pview:  # RD: needs some work!
+        pfile = call_plot('wprof',ham.profile,input, grid, output, z, stride=20, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if 'uprof' in pview or 'all' in pview:  # RD: needs some work!
+        output.load_reshape(grid,['Mh','Pressure', 'Rho'])
         u = (-output.Mh[0] * np.sin(grid.lon[:, None, None]) + output.Mh[1] * np.cos(grid.lon[:, None, None])) / output.Rho
         z = {'value': u, 'label': r'Zonal velocity (m s$^{-1}$)', 'name': 'U'}
-        ham.profile(input, grid, output, z, stride=20)
-    if 'cfl' in pview:
+        pfile = call_plot('uprof',ham.profile,input, grid, output, z, stride=20, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if 'cfl' in pview or 'all' in pview:
+        output.load_reshape(grid,['Pressure','Rho'])
         dt = output.time[0] / output.nstep[0] * 86400
         dx = np.sqrt(np.min(grid.areasT))
         cs = np.sqrt(input.Cp / (input.Cp - input.Rd) * output.Pressure / output.Rho)
         z = {'value': cs * dt / dx, 'label': 'CFL number for (horizontal) acoustic waves', 'name': 'CFL'}
-        ham.profile(input, grid, output, z, stride=20)
-    if 'bvprof' in pview:
+        pfile = call_plot('cfl',ham.profile,input, grid, output, z, stride=20, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if 'bvprof' in pview or 'all' in pview:
+        output.load_reshape(grid,['Pressure','Rho'])
         kappa_ad = input.Rd / input.Cp  # adiabatic coefficient
         T = output.Pressure / input.Rd / output.Rho
         pt = T * (output.Pressure / input.P_Ref)**(-kappa_ad)
         dptdr = np.gradient(pt, grid.Altitude, axis=1)
         N = np.sqrt(input.Gravit / pt * dptdr)
         z = {'value': N, 'label': r'$N$ (s$^{-1}$)', 'name': 'BVprof'}
-        ham.profile(input, grid, output, z, stride=20)
-    if 'fluxprof' in pview:
-        total_f = output.fnet_up - output.fnet_dn
-        fup = total_f[:, :-1, :] + (total_f[:, 1:, :] - total_f[:, :-1, :]) *\
+        pfile = call_plot('bvprof',ham.profile,input, grid, output, z, stride=20, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if ('DGfluxprof' in pview or 'all' in pview) and input.RT:
+
+        output.load_reshape(grid,['flw_up','fsw_dn','flw_dn'])
+        fnet_int = output.flw_up - output.flw_dn - output.fsw_dn
+        fnet = fnet_int[:, :-1, :] + (fnet_int[:, 1:, :] - fnet_int[:, :-1, :]) *\
             (grid.Altitude[None, :, None] - grid.Altitudeh[None, :-1, None]) /\
             (grid.Altitudeh[None, 1:, None] - grid.Altitudeh[None, :-1, None])
-        z = {'value': fup, 'label': r'Total flux (W m$^{-2}$)', 'name': 'ftot'}
-        ham.profile(input, grid, output, z, stride=20)
-    if 'futprof' in pview:
-        fup = output.f_up_tot[:, :-1, :]
-        z = {'value': fup, 'label': r'Total Upward flux (W m$^{-2}$)', 'name': 'fuptot'}
-        ham.profile(input, grid, output, z, stride=20)
-    if 'fdtprof' in pview:
-        fdn = output.f_down_tot[:, :-1, :]
-        z = {'value': fdn, 'label': r'Total Downward flux (W m$^{-2}$)', 'name': 'fdowntot'}
-        ham.profile(input, grid, output, z, stride=20)
-    if 'fnetprof' in pview:
-        fdn = output.f_net[:, :-1, :]
-        z = {'value': fdn, 'label': r'Total Net flux (W m$^{-2}$)', 'name': 'fnetprof'}
-        ham.profile(input, grid, output, z, stride=20)
+        z = {'value': fnet, 'label': r'Double Gray Net flux (W m$^{-2}$)', 'name': 'DGfnet'}
+        pfile = call_plot('DGfluxprof',ham.profile,input, grid, output, z, stride=20, save=save, axis=axis)
+        plots_created.append(pfile)
 
+    if ('TSfluxprof' in pview or 'all' in pview) and input.TSRT:
+
+        output.load_reshape(grid,['f_net'])
+        fnet_int = output.f_net
+        fnet = fnet_int[:, :-1, :] + (fnet_int[:, 1:, :] - fnet_int[:, :-1, :]) *\
+            (grid.Altitude[None, :, None] - grid.Altitudeh[None, :-1, None]) /\
+            (grid.Altitudeh[None, 1:, None] - grid.Altitudeh[None, :-1, None])
+        z = {'value': fnet, 'label': r'Two Stream Net flux (W m$^{-2}$)', 'name': 'TSfnet'}
+        pfile = call_plot('TSfluxprof',ham.profile,input, grid, output, z, stride=20, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if ('DGfutprof' in pview or 'all' in pview) and input.RT:
+
+        output.load_reshape(grid,['flw_up'])
+        fup_int = output.flw_up
+        fup = fup_int[:, :-1, :] + (fup_int[:, 1:, :] - fup_int[:, :-1, :]) *\
+            (grid.Altitude[None, :, None] - grid.Altitudeh[None, :-1, None]) /\
+            (grid.Altitudeh[None, 1:, None] - grid.Altitudeh[None, :-1, None])
+        z = {'value': fup, 'label': r'Double Gray Total Upward flux (W m$^{-2}$)', 'name': 'DGfuptot'}
+        pfile = call_plot('DGfutprof',ham.profile,input, grid, output, z, stride=20, save=save, axis=axis)
+        plots_created.append(pfile)
+
+
+    if ('TSfutprof' in pview or 'all' in pview) and input.TSRT:
+        output.load_reshape(grid,['f_up_tot'])
+        fup_int = output.f_up_tot
+        fup = fup_int[:, :-1, :] + (fup_int[:, 1:, :] - fup_int[:, :-1, :]) *\
+            (grid.Altitude[None, :, None] - grid.Altitudeh[None, :-1, None]) /\
+            (grid.Altitudeh[None, 1:, None] - grid.Altitudeh[None, :-1, None])
+        z = {'value': fup, 'label': r'Two Stream Total Upward flux (W m$^{-2}$)', 'name': 'TSfuptot'}
+        pfile = call_plot('TSfutprof',ham.profile,input, grid, output, z, stride=20, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if ('TSfdirprof' in pview or 'all' in pview) and input.TSRT:
+        output.load_reshape(grid,['f_dir_tot'])
+        fdir_int = output.f_dir_tot
+        fdir = fdir_int[:, :-1, :] + (fdir_int[:, 1:, :] - fdir_int[:, :-1, :]) *\
+            (grid.Altitude[None, :, None] - grid.Altitudeh[None, :-1, None]) /\
+            (grid.Altitudeh[None, 1:, None] - grid.Altitudeh[None, :-1, None])
+        z = {'value': fdir, 'label': r'Two Stream Total Directional flux (W m$^{-2}$)', 'name': 'TSfdirprof'}
+        pfile = call_plot('TSfdirprof',ham.profile,input, grid, output, z, stride=20, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if ('DGfdtprof' in pview or 'all' in pview) and input.RT:
+        output.load_reshape(grid,['flw_dn','fsw_dn'])
+        fdn_int = output.flw_dn + output.fsw_dn
+        fdn = fdn_int[:, :-1, :] + (fdn_int[:, 1:, :] - fdn_int[:, :-1, :]) *\
+            (grid.Altitude[None, :, None] - grid.Altitudeh[None, :-1, None]) /\
+            (grid.Altitudeh[None, 1:, None] - grid.Altitudeh[None, :-1, None])
+        z = {'value': fdn, 'label': r'Double Gray Total Downward flux (W m$^{-2}$)', 'name': 'DGfdowntot'}
+        pfile = call_plot('DGfdtprof',ham.profile,input, grid, output, z, stride=20, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if ('TSfdtprof' in pview or 'all' in pview) and input.TSRT:
+        output.load_reshape(grid,['f_down_tot'])
+        fdn_int = output.f_down_tot
+        fdn = fdn_int[:, :-1, :] + (fdn_int[:, 1:, :] - fdn_int[:, :-1, :]) *\
+            (grid.Altitude[None, :, None] - grid.Altitudeh[None, :-1, None]) /\
+            (grid.Altitudeh[None, 1:, None] - grid.Altitudeh[None, :-1, None])
+        z = {'value': fdn, 'label': r'Two Stream Total Downward flux (W m$^{-2}$)', 'name': 'TSfdowntot'}
+        pfile = call_plot('TSfdtprof',ham.profile,input, grid, output, z, stride=20, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if ('TSqheatprof' in pview or 'all' in pview) and input.TSRT:
+        output.load_reshape(grid,['TSqheat'])
+        qheat = output.TSqheat
+        z = {'value': qheat, 'label': r'Two Stream Q heat (W m$^{-2}$)', 'name': 'TSqheatprof'}
+        pfile = call_plot('TSqheatprof',ham.profile,input, grid, output, z, stride=20, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if ('DGqheatprof' in pview or 'all' in pview) and input.RT:
+        output.load_reshape(grid,['DGqheat'])
+        qheat = output.DGqheat
+        z = {'value': qheat, 'label': r'Double Gray Q heat (W m$^{-2}$)', 'name': 'DGqheatprof'}
+        pfile = call_plot('DGqheatprof',ham.profile,input, grid, output, z, stride=20, save=save, axis=axis)
+        plots_created.append(pfile)
+
+
+    if ('qheatprof' in pview or 'all' in pview):
+        output.load_reshape(grid,['qheat'])
+        qheat = output.qheat
+        z = {'value': qheat, 'label': r'Q heat (W m$^{-2}$)', 'name': 'qheatprof'}
+        pfile = call_plot('qheatprof',ham.profile,input, grid, output, z, stride=20, save=save, axis=axis)
+        plots_created.append(pfile)
+
+    if ('w0prof' in pview or 'all' in pview) and input.TSRT: # and input.has_w0_g0:
+        output.load_reshape(grid,['w0_band'])
+        num_bands = output.w0_band.shape[2]
+
+        num_plot_band_y = num_bands//4
+        if num_plot_band_y > 4:
+            num_plot_band_y = 4
+        num_plots = num_plot_band_y*4
+        stride = num_bands//num_plots
+        all_ax = axis[0].subplots(4, num_plot_band_y)
+        axes = [ax for sax in all_ax for ax in sax]
+        for i in range(num_plots):
+
+            w0 =  output.w0_band[:,:,i*stride,:]
+            lamda = output.wavelength[i][0]*1e6
+            z = {'value': w0, 'label': f"w0 - band {i*stride} - wl {lamda} um", 'name': 'w0'}
+            pfile = call_plot('w0',ham.profile,input, grid, output, z, stride=20, save=save, axis=(axis[0], axes[i]))
+            plots_created.append(pfile)
+
+    if ('g0prof' in pview or 'all' in pview) and input.TSRT: # and input.has_w0_g0:
+        output.load_reshape(grid,['g0_band'])
+        num_bands = output.g0_band.shape[2]
+
+        num_plot_band_y = num_bands//4
+        if num_plot_band_y > 4:
+            num_plot_band_y = 4
+        num_plots = num_plot_band_y*4
+        stride = num_bands//num_plots
+        all_ax = axis[0].subplots(4, num_plot_band_y)
+        axes = [ax for sax in all_ax for ax in sax]
+        for i in range(num_plots):
+
+            g0 =  output.g0_band[:,:,i*stride,:]
+            lamda = output.wavelength[i][0]*1e6
+            z = {'value': g0, 'label': f"g0 - band {i*stride} - wl {lamda} um", 'name': 'g0'}
+            pfile = call_plot('g0',ham.profile,input, grid, output, z, stride=20, save=save, axis=(axis[0], axes[i]))
+            plots_created.append(pfile)
     # --- Global diagnostics -----------------------------------
     if 'cons' in pview:  # RD: needs some work!
         if args.split_layer[0] == 'no_split':
@@ -528,12 +764,23 @@ def make_plot(args):
         else:
             split = np.float(args.split_layer[0]) * 100
         ham.conservation(input, grid, output, split)
+
     if 'KE' in pview:  # RD: needs some work!
         PR_LV = np.float(args.horizontal_lev[0]) * 100  # not actually used here
         ham.KE_spect(input, grid, output, PR_LV, coord=args.coordinate_sys[0], lmax_adjust=args.lmax_adjust[0])
+
     if 'SR' in pview:
         ham.SRindex(input, grid, output)
+
     if 'RTbalance' in pview:
         ham.RTbalance(input, grid, output)
+
+    if 'phase' in pview and input.RT:
+        ham.phase_curve(input,grid,output)
+
+    #some clean up
+    output.closeVDS()
+    if openrg:
+        rg.closeVDS()
 
     return plots_created

--- a/src/ESP/esp_initial.cu
+++ b/src/ESP/esp_initial.cu
@@ -343,6 +343,9 @@ __host__ void ESP::alloc_data(bool globdiag, bool output_mean) {
     cudaMalloc((void **)&diffv_d1, 6 * nv * point_num * sizeof(double));
     cudaMalloc((void **)&diffv_d2, 6 * nv * point_num * sizeof(double));
 
+
+    profx_Qheat_h = (double *)malloc(nv * point_num * sizeof(double));
+
     cudaMalloc((void **)&profx_Qheat_d, nv * point_num * sizeof(double));
     cudaMalloc((void **)&profx_dMh_d, 3 * nv * point_num * sizeof(double));
     cudaMalloc((void **)&profx_dWh_d, nvi * point_num * sizeof(double));
@@ -1203,6 +1206,8 @@ __host__ ESP::~ESP() {
     cudaFree(vtmp);
     cudaFree(wtmp);
     cudaFree(Ttmp);
+
+    free(profx_Qheat_h);
 
     cudaFree(profx_Qheat_d);
     cudaFree(profx_dMh_d);

--- a/src/ESP/esp_output.cu
+++ b/src/ESP/esp_output.cu
@@ -90,6 +90,9 @@ __host__ void ESP::copy_to_host() {
     cudaMemcpy(Mh_h, Mh_d, 3 * point_num * nv * sizeof(double), cudaMemcpyDeviceToHost);
     cudaMemcpy(Rd_h, Rd_d, point_num * nv * sizeof(double), cudaMemcpyDeviceToHost);
     cudaMemcpy(Cp_h, Cp_d, point_num * nv * sizeof(double), cudaMemcpyDeviceToHost);
+
+    cudaMemcpy(
+        profx_Qheat_h, profx_Qheat_d, point_num * nv * sizeof(double), cudaMemcpyDeviceToHost);
 }
 
 __host__ void ESP::copy_mean_to_host() {
@@ -318,6 +321,9 @@ __host__ void ESP::output(int                    fidx, // Index of output file
         //  GlobalAMz (total angular momentum in y direction over entire planet)
         s.append_value(GlobalAMz_h, "/GlobalAMz", "kg m^2/s", "Global AngMomZ");
     }
+
+    // profX Qheat from physics modules
+    s.append_table(profx_Qheat_h, nv * point_num, "/Qheat", "W m^-3", "Physics module Qheat");
 
     if (sim.output_mean == true) {
         //  Rho

--- a/src/headers/esp.h
+++ b/src/headers/esp.h
@@ -173,6 +173,9 @@ public:
     double *GibbsdG;
     int     GibbsN = 61;
 
+    // physics module Qheat, for output
+    double *profx_Qheat_h;
+
     ///////////////////////////
     //  Device
     int *point_local_d;

--- a/src/physics/modules/inc/radiative_transfer.h
+++ b/src/physics/modules/inc/radiative_transfer.h
@@ -70,7 +70,19 @@ public:
 
     void print_config();
 
+    void set_qheat_scaling(const double &scaling) {
+        Qheat_scaling = scaling;
+    };
+
+    // DEBUG: hack, for debug printout in Alf.
+    double *get_debug_qheat_device_ptr() {
+        return qheat_d;
+    };
+
 private:
+    // Scaling of Qheat, for slow ramp up or ramp down.
+    double Qheat_scaling = 1.0;
+
     // Config options
     double Tstar_config            = 4520;  // Star effective temperature [K]
     double planet_star_dist_config = 0.015; // Planet-star distance [au]
@@ -155,6 +167,9 @@ private:
     double *insol_d;
     double *insol_ann_h;
     double *insol_ann_d;
+
+    double *qheat_d;
+    double *qheat_h;
 
     //  These arrays are for temporary usage in RT code
     double *dtemp;

--- a/src/physics/modules/src/radiative_transfer.cu
+++ b/src/physics/modules/src/radiative_transfer.cu
@@ -100,6 +100,9 @@ bool radiative_transfer::initialise_memory(const ESP &              esp,
     cudaMalloc((void **)&ttemp, esp.nv * esp.point_num * sizeof(double));
     cudaMalloc((void **)&dtemp, esp.nv * esp.point_num * sizeof(double));
 
+    cudaMalloc((void **)&qheat_d, esp.nv * esp.point_num * sizeof(double));
+    qheat_h = (double *)malloc(esp.point_num * esp.nv * sizeof(double));
+
     insol_h = (double *)malloc(esp.point_num * sizeof(double));
     cudaMalloc((void **)&insol_d, esp.point_num * sizeof(double));
     insol_ann_h = (double *)malloc(esp.point_num * sizeof(double));
@@ -351,8 +354,13 @@ bool radiative_transfer::store(const ESP &esp, storage &s) {
                    " ",
                    "optical depth across each layer (not total optical depth)");
 
+    cudaMemcpy(qheat_h, qheat_d, esp.nv * esp.point_num * sizeof(double), cudaMemcpyDeviceToHost);
+    s.append_table(qheat_h, esp.nv * esp.point_num, "/DGQheat", " ", "Double Gray Qheat");
+
     cudaMemcpy(Tsurface_h, Tsurface_d, esp.point_num * sizeof(double), cudaMemcpyDeviceToHost);
     s.append_table(Tsurface_h, esp.point_num, "/Tsurface", "K", "surface temperature");
+
+    s.append_value(Qheat_scaling, "/dgrt_qheat_scaling", " ", "Qheat scaling applied to DG");
     return true;
 }
 


### PR DESCRIPTION
This restructures the python objects for plotting and regridding to a somewhat more streamlined way that utilizes virtual data sets to avoid memory overflow issues. Note that a number of plot options in this commit refer to alfrodull outputs which are not all fully implemented. Also includes THOR output of qheat and DGqheat variables. 