### PR TITLE
Vert diff testing

### DIFF
--- a/src/ESP/esp_initial.cu
+++ b/src/ESP/esp_initial.cu
@@ -857,8 +857,8 @@ __host__ bool ESP::initial_values(const std::string &initial_conditions_filename
     Kdh2_h = new double[nv];
     for (int lev = 0; lev < nv; lev++) {
         double dbar = sqrt(2 * M_PI / 5) * sim.A / (pow(2, glevel));
-        Kdh4_h[lev] =
-            (sim.Diffc) * pow(dbar, 4.) / timestep_dyn; // * Altitude_h[lev]/sim.Top_altitude;
+        Kdh4_h[lev] = (sim.Diffc) * pow(dbar, 1.0 * sim.HyDiffOrder)
+                      / timestep_dyn; // * Altitude_h[lev]/sim.Top_altitude;
         Kdhz_h[lev] =
             (sim.DivDampc) * pow(dbar, 4.) / timestep_dyn; // * Altitude_h[lev]/sim.Top_altitude;
         if (sim.DiffSponge) {

--- a/src/ESP/thor_driver.cu
+++ b/src/ESP/thor_driver.cu
@@ -315,7 +315,8 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
                                                   order_diff_sponge,
                                                   Kdh2_d,
                                                   boundary_flux_d,
-                                                  energy_equation);
+                                                  energy_equation,
+                                                  sim.HyDiffOrder);
 
                 //Updates: diffmh_d, diffw_d, diffrh_d, diffpr_d, diff_d
                 Diffusion_Op_Poles<5><<<NBDP, 1>>>(diffmh_d,
@@ -348,7 +349,8 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
                                                    order_diff_sponge,
                                                    Kdh2_d,
                                                    boundary_flux_d,
-                                                   energy_equation);
+                                                   energy_equation,
+                                                   sim.HyDiffOrder);
                 cudaDeviceSynchronize();
             }
 
@@ -388,7 +390,8 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
                                               order_diff_sponge,
                                               Kdh2_d,
                                               boundary_flux_d,
-                                              energy_equation);
+                                              energy_equation,
+                                              sim.HyDiffOrder);
             //Updates: diffmh_d, diffw_d, diffrh_d, diffpr_d, diff_d
             Diffusion_Op_Poles<5><<<NBDP, 1>>>(diffmh_d,
                                                diffw_d,
@@ -420,7 +423,8 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
                                                order_diff_sponge,
                                                Kdh2_d,
                                                boundary_flux_d,
-                                               energy_equation);
+                                               energy_equation,
+                                               sim.HyDiffOrder);
 
             cudaDeviceSynchronize();
 

--- a/src/ESP/thor_driver.cu
+++ b/src/ESP/thor_driver.cu
@@ -126,7 +126,6 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
                    "temperature_d",
                    "W_d" /*, "tracer_d", "tracers_d", "tracerk_d"*/));
 
-
     //  Loop for large time integration.
     for (int rk = 0; rk < 3; rk++) {
         //      Local variables to define the length (times) and the number of the small steps (ns_it).
@@ -280,69 +279,78 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
             cudaMemset(diff_d, 0, sizeof(double) * 6 * point_num * nv);
 
             cudaDeviceSynchronize();
-            //Updates: diffmh_d, diffw_d, diffrh_d, diffpr_d, diff_d
-            Diffusion_Op<LN, LN><<<NBD, NT>>>(diffmh_d,
-                                              diffw_d,
-                                              diffrh_d,
-                                              diffpr_d,
-                                              diff_d,
-                                              Mhk_d,
-                                              Rhok_d,
-                                              temperature_d,
-                                              Wk_d,
-                                              areasTr_d,
-                                              areas_d,
-                                              nvecoa_d,
-                                              nvecti_d,
-                                              nvecte_d,
-                                              func_r_d,
-                                              Kdh4_d,
-                                              Altitude_d,
-                                              sim.A,
-                                              Rd_d,
-                                              Cp_d,
-                                              maps_d,
-                                              nl_region,
-                                              0,
-                                              sim.DeepModel,
-                                              sim.DiffSponge,
-                                              order_diff_sponge,
-                                              Kdh2_d,
-                                              boundary_flux_d,
-                                              energy_equation);
+            bool firststep;
+            for (int ihyp = 0; ihyp < sim.HyDiffOrder / 2 - 1; ihyp++) {
+                if (ihyp == 0)
+                    firststep = 1;
+                else
+                    firststep = 0;
+                //Updates: diffmh_d, diffw_d, diffrh_d, diffpr_d, diff_d
+                Diffusion_Op<LN, LN><<<NBD, NT>>>(diffmh_d,
+                                                  diffw_d,
+                                                  diffrh_d,
+                                                  diffpr_d,
+                                                  diff_d,
+                                                  Mhk_d,
+                                                  Rhok_d,
+                                                  temperature_d,
+                                                  Wk_d,
+                                                  areasTr_d,
+                                                  areas_d,
+                                                  nvecoa_d,
+                                                  nvecti_d,
+                                                  nvecte_d,
+                                                  func_r_d,
+                                                  Kdh4_d,
+                                                  Altitude_d,
+                                                  sim.A,
+                                                  Rd_d,
+                                                  Cp_d,
+                                                  maps_d,
+                                                  nl_region,
+                                                  firststep,
+                                                  0,
+                                                  sim.DeepModel,
+                                                  sim.DiffSponge,
+                                                  order_diff_sponge,
+                                                  Kdh2_d,
+                                                  boundary_flux_d,
+                                                  energy_equation);
 
-            //Updates: diffmh_d, diffw_d, diffrh_d, diffpr_d, diff_d
-            Diffusion_Op_Poles<5><<<NBDP, 1>>>(diffmh_d,
-                                               diffw_d,
-                                               diffrh_d,
-                                               diffpr_d,
-                                               diff_d,
-                                               Mhk_d,
-                                               Rhok_d,
-                                               temperature_d,
-                                               Wk_d,
-                                               func_r_d,
-                                               areasTr_d,
-                                               areas_d,
-                                               nvecoa_d,
-                                               nvecti_d,
-                                               nvecte_d,
-                                               Kdh4_d,
-                                               Altitude_d,
-                                               Altitudeh_d,
-                                               sim.A,
-                                               Rd_d,
-                                               Cp_d,
-                                               point_local_d,
-                                               point_num,
-                                               0,
-                                               sim.DeepModel,
-                                               sim.DiffSponge,
-                                               order_diff_sponge,
-                                               Kdh2_d,
-                                               boundary_flux_d,
-                                               energy_equation);
-            cudaDeviceSynchronize();
+                //Updates: diffmh_d, diffw_d, diffrh_d, diffpr_d, diff_d
+                Diffusion_Op_Poles<5><<<NBDP, 1>>>(diffmh_d,
+                                                   diffw_d,
+                                                   diffrh_d,
+                                                   diffpr_d,
+                                                   diff_d,
+                                                   Mhk_d,
+                                                   Rhok_d,
+                                                   temperature_d,
+                                                   Wk_d,
+                                                   func_r_d,
+                                                   areasTr_d,
+                                                   areas_d,
+                                                   nvecoa_d,
+                                                   nvecti_d,
+                                                   nvecte_d,
+                                                   Kdh4_d,
+                                                   Altitude_d,
+                                                   Altitudeh_d,
+                                                   sim.A,
+                                                   Rd_d,
+                                                   Cp_d,
+                                                   point_local_d,
+                                                   point_num,
+                                                   firststep,
+                                                   0,
+                                                   sim.DeepModel,
+                                                   sim.DiffSponge,
+                                                   order_diff_sponge,
+                                                   Kdh2_d,
+                                                   boundary_flux_d,
+                                                   energy_equation);
+                cudaDeviceSynchronize();
+            }
 
             BENCH_POINT_I_S(current_step, rk, "Diffusion_Op1", (), ("diff_d"))
             //  ("diffmh_d", "diffw_d", "diffrh_d", "diffpr_d", "diff_d"))
@@ -373,6 +381,7 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
                                               Cp_d,
                                               maps_d,
                                               nl_region,
+                                              0,
                                               1,
                                               sim.DeepModel,
                                               sim.DiffSponge,
@@ -404,6 +413,7 @@ __host__ void ESP::Thor(const SimulationSetup& sim, kernel_diagnostics& diag) {
                                                Cp_d,
                                                point_local_d,
                                                point_num,
+                                               0,
                                                1,
                                                sim.DeepModel,
                                                sim.DiffSponge,

--- a/src/esp.cu
+++ b/src/esp.cu
@@ -297,6 +297,7 @@ int main(int argc, char** argv) {
     // Diffusion
 
     config_reader.append_config_var("HyDiff", sim.HyDiff, HyDiff_default);
+    config_reader.append_config_var("HyDiffOrder", sim.HyDiffOrder, HyDiffOrder_default);
     config_reader.append_config_var("DivDampP", sim.DivDampP, DivDampP_default);
     config_reader.append_config_var("VertHyDiff", sim.VertHyDiff, VertHyDiff_default);
 
@@ -541,6 +542,11 @@ int main(int argc, char** argv) {
     else {
         log::printf("Bad value for config variable simulation_ID: [%s]\n", simulation_ID.c_str());
 
+        config_OK = false;
+    }
+
+    if (sim.HyDiffOrder <= 2 || sim.HyDiffOrder % 2) {
+        log::printf("Bad value for HyDiffOrder! Must be power of 2 greater than/equal to 4.");
         config_OK = false;
     }
 

--- a/src/esp.cu
+++ b/src/esp.cu
@@ -546,7 +546,7 @@ int main(int argc, char** argv) {
     }
 
     if (sim.HyDiffOrder <= 2 || sim.HyDiffOrder % 2) {
-        log::printf("Bad value for HyDiffOrder! Must be power of 2 greater than/equal to 4.");
+        log::printf("Bad value for HyDiffOrder! Must be multiple of 2 greater than/equal to 4.");
         config_OK = false;
     }
 

--- a/src/headers/define.h
+++ b/src/headers/define.h
@@ -76,7 +76,8 @@
 #define t_shrink_default 144000     // shrink sponge after this many time steps
 
 // Diffusion
-#define HyDiff_default true      // Hyper-diffusion
+#define HyDiff_default true // Hyper-diffusion
+#define HyDiffOrder_default 4
 #define DivDampP_default true    // Divergence-damping
 #define VertHyDiff_default false // Vertical Hyper-diffusion
 

--- a/src/headers/dyn/thor_diff.h
+++ b/src/headers/dyn/thor_diff.h
@@ -81,7 +81,8 @@ __global__ void Diffusion_Op(double* diffmh_d,
                              int     order_diff_sponge,
                              double* Kdh2_d,
                              double* boundary_flux_d,
-                             bool    energy_equation) {
+                             bool    energy_equation,
+                             int     HyDiffOrder) {
 
     int x = threadIdx.x;
     int y = threadIdx.y;
@@ -302,7 +303,7 @@ __global__ void Diffusion_Op(double* diffmh_d,
         rscale = 1.0;
 
     if (laststep) {
-        sdiff = -K_d[lev];
+        sdiff = -K_d[lev] * pow(-1.0, HyDiffOrder / 2);
     }
 
     lap = 0.0;
@@ -514,7 +515,8 @@ __global__ void Diffusion_Op_Poles(double* diffmh_d,
                                    int     order_diff_sponge,
                                    double* Kdh2_d,
                                    double* boundary_flux_d,
-                                   bool    energy_equation) {
+                                   bool    energy_equation,
+                                   int     HyDiffOrder) {
 
     int id = blockIdx.x * blockDim.x + threadIdx.x;
     id += num - 2; // Poles
@@ -567,7 +569,7 @@ __global__ void Diffusion_Op_Poles(double* diffmh_d,
         Rho_p[i] = Rho_d[local_p[i - 1] * nv + lev];
 
     if (laststep) {
-        sdiff = -K_d[lev];
+        sdiff = -K_d[lev] * pow(-1.0, HyDiffOrder / 2);
     }
 
     // if (laststep) {

--- a/src/headers/simulation_setup.h
+++ b/src/headers/simulation_setup.h
@@ -82,7 +82,8 @@ public:
 
     // Sim
     bool DeepModel;
-    bool HyDiff;     // Turn on/off hyper-diffusion.
+    bool HyDiff; // Turn on/off hyper-diffusion.
+    int  HyDiffOrder;
     bool DivDampP;   // Turn on/off divergence damping.
     bool VertHyDiff; // vertical hyper diffusion
     bool NonHydro;   // Turn on/off non-hydrostatic.

--- a/src/utils/binary_test.cpp
+++ b/src/utils/binary_test.cpp
@@ -290,13 +290,13 @@ map<string, output_def> build_definitions(ESP& esp, Icogrid& grid) {
           std::bind(
               &ESP::index_to_location_scalar, &esp, std::placeholders::_1, std::placeholders::_2)}},
 
-        {"diffv_d",
-         {esp.diffv_d2,
-          6 * esp.nv * esp.point_num,
-          "Diff Vert",
-          "difv",
-          true,
-          std::bind(&ESP::dummy, &esp, std::placeholders::_1, std::placeholders::_2)}},
+        // {"diffv_d",
+        //  {esp.diffv_d2,
+        //   6 * esp.nv * esp.point_num,
+        //   "Diff Vert",
+        //   "difv",
+        //   true,
+        //   std::bind(&ESP::dummy, &esp, std::placeholders::_1, std::placeholders::_2)}},
 
 
         {"DivM_d",


### PR DESCRIPTION
Added switch to increase order of horizontal hyperdiffusion. This is experimental. Execution with HyDiffOrder = 4 is at least identical to old versions, but it is not clear how to tune diffusion coefficient for HyDiffOrder = 6, 8, etc. It seems to need to be much smaller than for order 4 in order to run without crashing. I am not certain I haven't made any mistakes. Hopefully Mark can test whether it behaves in a physically reasonable way. 